### PR TITLE
Add simulation box visualization

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -1,6 +1,6 @@
 
 export { Molvis } from './app';
-export { System } from './system';
+export { System, Box } from './system';
 export { World } from './world';
 export { GuiManager } from './gui';
 export type { IEntity } from './system';

--- a/core/src/system/box.ts
+++ b/core/src/system/box.ts
@@ -1,4 +1,11 @@
-import { Matrix, Vector3 } from "@babylonjs/core";
+import {
+  Matrix,
+  Vector3,
+  MeshBuilder,
+  type Scene,
+  type LinesMesh,
+  Color3,
+} from "@babylonjs/core";
 
 /**
  * Box class for molecular dynamics simulations
@@ -409,5 +416,31 @@ export class Box {
             
             return new Box(newVectors);
         }
+    }
+
+    /**
+     * Create a Babylon.js LinesMesh representation of the box for visualization
+     *
+     * @param scene - Scene where the mesh will be created
+     * @param name - Mesh name
+     * @param color - Line color
+     */
+    public toLinesMesh(
+        scene: Scene,
+        name = "simulationBox",
+        color: Color3 = Color3.White(),
+    ): LinesMesh {
+        const c = this.get_corners();
+        const lines = [
+            [c[0], c[1], c[3], c[2], c[0]],
+            [c[4], c[5], c[7], c[6], c[4]],
+            [c[0], c[4]],
+            [c[1], c[5]],
+            [c[2], c[6]],
+            [c[3], c[7]],
+        ];
+        const mesh = MeshBuilder.CreateLineSystem(name, { lines }, scene);
+        mesh.color = color;
+        return mesh;
     }
 }

--- a/core/src/system/index.ts
+++ b/core/src/system/index.ts
@@ -1,6 +1,7 @@
 import { Frame } from './frame';
 import { Atom } from './item';
 import { Trajectory } from './trajectory';
+import { Box } from './box';
 import { IEntity } from './base';
 
 class System {
@@ -64,5 +65,5 @@ class System {
 
 
 
-export { System };
-export type { IEntity }
+export { System, Box };
+export type { IEntity };

--- a/core/src/world/world.ts
+++ b/core/src/world/world.ts
@@ -7,9 +7,11 @@ import {
   Scene,
   Vector3,
   Tools,
+  type LinesMesh,
 } from "@babylonjs/core";
 import { AxisHelper } from "./axes";
 import { Pipeline } from "../pipeline";
+import { Box } from "../system";
 
 // import { Logger } from "tslog";
 // const logger = new Logger({ name: "molvis-world" });
@@ -20,6 +22,7 @@ class World {
   private _camera: ArcRotateCamera;
   private _axes: AxisHelper;
   private _pipeline: Pipeline;
+  private _boxMesh: LinesMesh | null = null;
 
   constructor(canvas: HTMLCanvasElement, ) {
     this._engine = this._initEngine(canvas);
@@ -88,6 +91,13 @@ class World {
     this._pipeline.append(name, args);
   }
 
+  public drawBox(box: Box, color: Color3 = Color3.White()) {
+    if (this._boxMesh) {
+      this._boxMesh.dispose();
+    }
+    this._boxMesh = box.toLinesMesh(this._scene, "simulation_box", color);
+  }
+
   public takeScreenShot() {
     Tools.CreateScreenshot(this._engine, this._camera, {precision: 1.0});
   }
@@ -112,6 +122,10 @@ class World {
     while (this._scene.meshes.length) {
       const mesh = this._scene.meshes[0];
       mesh.dispose();
+    }
+    if (this._boxMesh) {
+      this._boxMesh.dispose();
+      this._boxMesh = null;
     }
   }
 

--- a/core/tests/index.ts
+++ b/core/tests/index.ts
@@ -1,4 +1,5 @@
-import { Molvis } from '../src/app';
+import { Molvis, Box } from '../src';
+import { Vector3, Color3 } from '@babylonjs/core';
 
 document.documentElement.lang = 'en';
 document.head.insertAdjacentHTML('afterbegin', `
@@ -15,49 +16,23 @@ html, body {
     margin: 0;
     padding: 0;
     overflow: hidden;
-    }
-    #molvisCanvas {
-        width: 100%;
-        height: 100%;
-        touch-action: none;
-        }
-        `;
+}
+#molvisCanvas {
+    width: 100%;
+    height: 100%;
+    touch-action: none;
+}
+`;
 document.body.appendChild(canvas);
 document.head.appendChild(style);
 
-
-// Initialize Molvis
+// Initialize Molvis and draw a simple box
 const app = new Molvis(canvas);
-
-// app.execute("draw_frame", {
-//     x: [0.00000, 0.75695, -0.75695],
-//     y: [-0.06556, 0.52032, 0.52032],
-//     z: [0.00000, 0.00000, 0.00000],
-//     name: ["O", "H", "H"],
-//     element: ["O", "H", "H"],
-//     bond_i: [0, 0],
-//     bond_j: [1, 2],
-// })
-
-app.modify(
-    "type_select", {
-        type: "O",
-        highlight: true
-    }
-)
-
-app.execute("draw_atom", {
-    x: 0.00000,
-    y: -0.06556,
-    z: 0.00000,
-    name: "O",
-    type: "O",
-});
-
-
+const box = new Box(new Vector3(5, 5, 5));
+app.world.drawBox(box, Color3.Red());
 app.render();
 
-console.log('Molvis initialized');
+console.log('Molvis box test initialized');
 
 // Handle window resize
 window.addEventListener('resize', () => {


### PR DESCRIPTION
## Summary
- expose `Box` through system and root exports
- draw simulation box lines via `Box.toLinesMesh`
- add world API to render a simulation box
- switch example entry to TypeScript

## Testing
- `npm run -s build -w core`


------
https://chatgpt.com/codex/tasks/task_e_683f7393cc488324ae6dd1e1167ccd70