### PR TITLE
rename: PyPI distribution to molcrafts-molvis

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "molvis"
+name = "molcrafts-molvis"
 version = "0.0.3"
 description = "Molecular visualization driven by a local WebSocket-hosted page"
 readme = "README.md"


### PR DESCRIPTION
PyPI release of v0.0.3 failed with trusted-publishing exchange error because the bare `molvis` name is owned by an unrelated 3dmol.js wrapper (Jon Kragskow, 0.4.2). Switch to the scoped `molcrafts-molvis` — same convention as `@molcrafts/molrs` on npm and `molcrafts-molrs` on crates.io. Wheel still packages `src/molvis` so `import molvis` is unchanged for end users.

After merge, the v0.0.3 tag needs to be re-created on the new HEAD so release.yaml re-triggers. Blocker until then: PyPI pending publisher for `molcrafts-molvis` must be added (https://pypi.org/manage/account/publishing/) pointing at MolCrafts/molvis workflow release.yaml environment pypi.