### PR TITLE
chore(ci): normalize workflow names and file extensions

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -1,4 +1,4 @@
-name: Release Core
+name: "Release: Core (npm)"
 
 on:
   push:

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -1,12 +1,11 @@
-name: Release
+name: "Release: Python (PyPI)"
 
 on:
   push:
-    tags:
-      - "v*"
+    tags: ["v*"]
 
 jobs:
-  release-python:
+  publish:
     name: Build & publish Python package
     runs-on: ubuntu-latest
     environment: pypi

--- a/.github/workflows/release-vsc-ext.yml
+++ b/.github/workflows/release-vsc-ext.yml
@@ -1,4 +1,4 @@
-name: Release VSCode Extension
+name: "Release: VSCode Extension"
 
 on:
   push:


### PR DESCRIPTION
## Summary
- Unify display names across the three publish workflows under a `Release: <target>` prefix so they group together in the Actions sidebar
- Rename `release.yaml` → `release-python.yml` so all four workflow files share the `.yml` extension
- Rename the Python release job key from `release-python` → `publish` to match the other release workflows

| File | Old `name:` | New `name:` |
|------|-------------|-------------|
| `ci.yml` | CI | CI *(unchanged)* |
| `release-core.yml` | Release Core | Release: Core (npm) |
| `release-python.yml` *(was `release.yaml`)* | Release | Release: Python (PyPI) |
| `release-vsc-ext.yml` | Release VSCode Extension | Release: VSCode Extension |

## Test plan
- [ ] Visual check: Actions sidebar shows `CI` + three `Release: …` entries grouped together
- [ ] Next `v*` tag fires all three release workflows under the new names