### PR TITLE
ci(release-core): use corepack to install npm (Node 22.22.2 toolcache bug)

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -3,6 +3,9 @@ name: "Release: Core (npm)"
 on:
   push:
     tags: ["v*"]
+  # Manual trigger for republishing after workflow fixes or transient infra
+  # failures, without needing to delete/recreate the release tag.
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -20,8 +23,17 @@ jobs:
           cache: npm
           registry-url: https://registry.npmjs.org
 
-      # Trusted Publishing (OIDC) requires npm >= 11.5.1
-      - run: npm install -g npm@latest
+      # Trusted Publishing (OIDC) requires npm >= 11.5.1, but the npm bundled
+      # with the Node 22 hostedtoolcache image has been shipping with a broken
+      # node_modules tree (missing `promise-retry` in arborist), which makes
+      # `npm install -g npm@latest` fail before it can upgrade itself.
+      # Using corepack sidesteps the broken shipped npm — it downloads and
+      # activates the requested npm version directly.
+      - name: Install npm 11 via corepack
+        run: |
+          corepack enable
+          corepack prepare npm@11.5.1 --activate
+          npm --version
 
       - run: npm ci
 

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@molcrafts/molvis-core",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "type": "module",
   "exports": {
     ".": {

--- a/core/package.json
+++ b/core/package.json
@@ -10,6 +10,10 @@
     "./io": {
       "types": "./dist/io/index.d.ts",
       "import": "./dist/io/index.js"
+    },
+    "./io/formats": {
+      "types": "./dist/io/formats.d.ts",
+      "import": "./dist/io/formats.js"
     }
   },
   "files": ["dist", "README.md", "LICENSE"],

--- a/core/src/app.ts
+++ b/core/src/app.ts
@@ -40,13 +40,21 @@ import { World } from "./world";
 import { type Box, Frame } from "@molcrafts/molrs";
 import { createMolvisDOM, registerWebComponents } from "./dom_helpers";
 import { OverlayManager } from "./overlays/overlay_manager";
-import { TextLabelOverlay } from "./overlays/text_label";
+import type { AtomAnchored, Overlay } from "./overlays/types";
 import { defaultSaveFile } from "./save_file";
 import { DType } from "./utils/dtype";
 
 interface StructuralSelectionSnapshot {
   atomIds: number[];
   hasExpressionSelection: boolean;
+}
+
+function asAtomAnchored(overlay: Overlay): AtomAnchored | null {
+  const a = overlay as Partial<AtomAnchored>;
+  return typeof a.getAnchorAtomId === "function" &&
+    typeof a.syncToAtomPosition === "function"
+    ? (a as AtomAnchored)
+    : null;
 }
 
 export class MolvisApp {
@@ -185,9 +193,10 @@ export class MolvisApp {
       this._lastSelectionSet = new Map(context.selectionSet);
     });
 
-    // Sync text label anchors to atom positions on each frame render.
+    // Sync atom-anchored overlays (text labels, highlight halos, ...) on each
+    // frame render so they follow their atom across the trajectory.
     this.events.on("frame-rendered", ({ frame }) => {
-      this._syncTextLabelAnchors(frame);
+      this._syncAnchoredOverlays(frame);
     });
   }
 
@@ -414,7 +423,7 @@ export class MolvisApp {
     }
   }
 
-  private _syncTextLabelAnchors(frame: Frame): void {
+  private _syncAnchoredOverlays(frame: Frame): void {
     const atoms = frame.getBlock("atoms");
     if (!atoms) return;
     const x = atoms.dtype("x") === DType.F64 ? atoms.viewColF("x") : undefined;
@@ -423,10 +432,11 @@ export class MolvisApp {
     if (!x || !y || !z) return;
 
     for (const overlay of this.overlayManager.list()) {
-      if (!(overlay instanceof TextLabelOverlay)) continue;
-      const atomId = overlay.props.anchorAtomId;
+      const anchored = asAtomAnchored(overlay);
+      if (!anchored) continue;
+      const atomId = anchored.getAnchorAtomId();
       if (atomId < 0 || atomId >= x.length) continue;
-      overlay.syncToAtomPosition(x[atomId], y[atomId], z[atomId]);
+      anchored.syncToAtomPosition(x[atomId], y[atomId], z[atomId]);
     }
   }
 

--- a/core/src/commands/index.ts
+++ b/core/src/commands/index.ts
@@ -35,6 +35,11 @@ export {
   UpdateOverlayCommand,
   AddOverlaySnapshotCommand,
 } from "./overlays";
+export {
+  MarkAtomCommand,
+  UnmarkAtomCommand,
+  RemarkAtomCommand,
+} from "./mark_atom";
 
 export type { GetSelectedResponse } from "../selection_manager";
 
@@ -57,6 +62,7 @@ import "./snapshot";
 import "./attributes";
 import "./representation";
 import "./overlays";
+import "./mark_atom";
 
 /**
  * Ensure the default command set is registered with the global `commands`

--- a/core/src/commands/mark_atom.ts
+++ b/core/src/commands/mark_atom.ts
@@ -1,0 +1,130 @@
+/**
+ * mark_atom / unmark_atom — first-class commands for marking atoms.
+ *
+ * A "mark" is a composite annotation (shape + optional label) that pins to an
+ * atom and follows it across trajectory frames. Stored internally in
+ * `OverlayManager` alongside arrows and text labels, but exposed as its own
+ * domain-level command pair so callers think in terms of "mark this atom",
+ * not "add an overlay of type mark_atom".
+ *
+ * Undo symmetry: mark_atom ↔ unmark_atom. The overlay instance is carried
+ * as a snapshot across the pair so redo reinstates the exact same object.
+ */
+
+import type { MolvisApp } from "../app";
+import { MarkAtomOverlay } from "../overlays/mark_atom";
+import type { MarkAtomProps } from "../overlays/types";
+import { Command, command } from "./base";
+
+// ── mark_atom ────────────────────────────────────────────────────────────────
+
+/**
+ * Mark an atom (or world position) with a halo and/or a text label.
+ *
+ * Usage:
+ *   app.execute("mark_atom", { anchorAtomId: 0 })
+ *   app.execute("mark_atom", { anchorAtomId: 3, label: { text: "*" } })
+ *   app.execute("mark_atom", { position: [1, 0, 0], shape: null, label: { text: "α" } })
+ *
+ * Returns the created MarkAtomOverlay (use `.id` for later unmark/update).
+ */
+@command("mark_atom")
+export class MarkAtomCommand extends Command<MarkAtomOverlay> {
+  private readonly _props: MarkAtomProps;
+  private _added: MarkAtomOverlay | null = null;
+
+  constructor(app: MolvisApp, args: MarkAtomProps) {
+    super(app);
+    this._props = args;
+  }
+
+  do(): MarkAtomOverlay {
+    const overlay = MarkAtomOverlay.create(
+      this.app.scene,
+      this._props,
+      this.app.overlayManager.labelTexture,
+    );
+    this._added = overlay;
+    this.app.overlayManager.add(overlay);
+    this.app.events.emit("overlay-added", { overlay });
+    return overlay;
+  }
+
+  undo(): UnmarkAtomCommand {
+    if (!this._added) {
+      throw new Error("Cannot undo mark_atom before the mark is created");
+    }
+    return new UnmarkAtomCommand(this.app, {
+      id: this._added.id,
+      _snapshot: this._added,
+    });
+  }
+}
+
+// ── unmark_atom ──────────────────────────────────────────────────────────────
+
+/**
+ * Remove a mark by id.
+ * Usage: app.execute("unmark_atom", { id: "mark_atom_1" })
+ *
+ * No-ops silently if the id does not match a current mark, so callers can
+ * use it defensively without a prior existence check.
+ */
+@command("unmark_atom")
+export class UnmarkAtomCommand extends Command<void> {
+  private readonly _id: string;
+  private _snapshot: MarkAtomOverlay | null;
+
+  constructor(
+    app: MolvisApp,
+    args: { id: string; _snapshot?: MarkAtomOverlay | null },
+  ) {
+    super(app);
+    this._id = args.id;
+    this._snapshot = args._snapshot ?? null;
+  }
+
+  do(): void {
+    if (!this._snapshot) {
+      const existing = this.app.overlayManager.get(this._id);
+      if (existing instanceof MarkAtomOverlay) this._snapshot = existing;
+    }
+    this.app.overlayManager.remove(this._id);
+    this.app.events.emit("overlay-removed", { id: this._id });
+  }
+
+  undo(): RemarkAtomCommand {
+    if (!this._snapshot) {
+      throw new Error("Cannot undo unmark_atom without a saved mark snapshot");
+    }
+    return new RemarkAtomCommand(this.app, this._snapshot);
+  }
+}
+
+// ── Internal: re-add a previously removed mark (for redo of unmark) ──────────
+
+/**
+ * Re-adds an already-constructed MarkAtomOverlay object.
+ * Not RPC-exposed — only reachable via UnmarkAtomCommand.undo().
+ */
+export class RemarkAtomCommand extends Command<MarkAtomOverlay> {
+  constructor(
+    app: MolvisApp,
+    private readonly _overlay: MarkAtomOverlay,
+  ) {
+    super(app);
+  }
+
+  do(): MarkAtomOverlay {
+    this.app.overlayManager.add(this._overlay);
+    this.app.events.emit("overlay-added", { overlay: this._overlay });
+    return this._overlay;
+  }
+
+  undo(): UnmarkAtomCommand {
+    return new UnmarkAtomCommand(this.app, {
+      id: this._overlay.id,
+      _snapshot: this._overlay,
+    });
+  }
+}

--- a/core/src/commands/overlays.ts
+++ b/core/src/commands/overlays.ts
@@ -20,6 +20,11 @@ import { VectorFieldOverlay } from "../overlays/vector_field";
 import { Command, command } from "./base";
 
 // ── Factory helper ────────────────────────────────────────────────────────────
+//
+// `add_overlay` handles the generic decoration overlays. Atom marks have their
+// own first-class commands — see commands/mark_atom.ts. Keeping those out of
+// this union means a caller who wants to mark an atom cannot accidentally
+// reach for `add_overlay({ type: "mark_atom" })`: there is one door per concept.
 
 type OverlaySpec =
   | ({ type: "arrow3d" } & Arrow3DProps)

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -173,12 +173,17 @@ export { Arrow3DOverlay } from "./overlays/arrow3d";
 export { Arrow2DOverlay } from "./overlays/arrow2d";
 export { TextLabelOverlay } from "./overlays/text_label";
 export { VectorFieldOverlay } from "./overlays/vector_field";
+export { MarkAtomOverlay } from "./overlays/mark_atom";
 export type {
   Overlay,
+  AtomAnchored,
   Arrow3DProps,
   Arrow2DProps,
   TextLabelProps,
   VectorFieldProps,
+  MarkAtomProps,
+  MarkShape,
+  MarkLabel,
 } from "./overlays/types";
 export { VectorFieldModifier } from "./modifiers/VectorFieldModifier";
 export type { VectorFieldModifierConfig } from "./modifiers/VectorFieldModifier";
@@ -187,6 +192,7 @@ export {
   RemoveOverlayCommand,
   UpdateOverlayCommand,
 } from "./commands/overlays";
+export { MarkAtomCommand, UnmarkAtomCommand } from "./commands/mark_atom";
 
 export { registerDefaultCommands } from "./commands";
 export { registerDefaultModifiers } from "./pipeline/modifier_registry";

--- a/core/src/io/formats.ts
+++ b/core/src/io/formats.ts
@@ -1,0 +1,98 @@
+/**
+ * File-format registry and extension inference.
+ *
+ * This module intentionally has **no dependencies** on the rest of core
+ * (no BabylonJS, no WASM, no logger) so that host-side tooling — such as
+ * the VS Code extension's activation bundle — can import the registry and
+ * run `inferFormatFromFilename` / `getAllAcceptExtensions` without
+ * dragging in the rendering engine. The parser dispatch itself lives in
+ * `reader.ts`, which imports from here.
+ */
+
+export type FileFormat = "pdb" | "xyz" | "lammps" | "lammps-dump";
+
+export interface FileFormatDescriptor {
+  readonly format: FileFormat;
+  readonly label: string;
+  readonly description: string;
+  readonly extensions: readonly string[];
+}
+
+export const FILE_FORMAT_REGISTRY: readonly FileFormatDescriptor[] = [
+  {
+    format: "pdb",
+    label: "Protein Data Bank",
+    description: "RCSB PDB-style ATOM/HETATM records (.pdb, .ent, .brk)",
+    extensions: ["pdb", "ent", "brk"],
+  },
+  {
+    format: "xyz",
+    label: "XYZ / Extended XYZ",
+    description:
+      "Cartesian coordinates, optional properties header (.xyz, .extxyz, .exyz)",
+    extensions: ["xyz", "extxyz", "exyz"],
+  },
+  {
+    format: "lammps",
+    label: "LAMMPS Data",
+    description:
+      "LAMMPS data / restart-text file (.data, .lmp, .lammps, .lammpsdata)",
+    extensions: ["data", "lmp", "lammps", "lammpsdata"],
+  },
+  {
+    format: "lammps-dump",
+    label: "LAMMPS Dump / Trajectory",
+    description:
+      "LAMMPS dump trajectory (.dump, .lammpstrj, .lmptrj, .lammpsdump)",
+    extensions: ["dump", "lammpstrj", "lmptrj", "lammpsdump"],
+  },
+];
+
+/** Returns the descriptor for a canonical FileFormat. */
+export function describeFormat(format: FileFormat): FileFormatDescriptor {
+  const descriptor = FILE_FORMAT_REGISTRY.find((d) => d.format === format);
+  if (!descriptor) {
+    throw new Error(`No descriptor registered for format "${format}"`);
+  }
+  return descriptor;
+}
+
+/**
+ * Flat list of every registered extension, prefixed with `.` — suitable
+ * for use directly as the `accept` attribute of a file input, or as the
+ * `filters` array of a VS Code quick-pick.
+ */
+export function getAllAcceptExtensions(): string {
+  const exts: string[] = [];
+  for (const entry of FILE_FORMAT_REGISTRY) {
+    for (const ext of entry.extensions) {
+      exts.push(`.${ext}`);
+    }
+  }
+  return exts.join(",");
+}
+
+function extensionOf(filename: string): string {
+  const trimmed = filename.trim();
+  const dot = trimmed.lastIndexOf(".");
+  return dot >= 0 ? trimmed.slice(dot + 1).toLowerCase() : "";
+}
+
+/**
+ * Infer a file format from the filename extension. Returns `null` when
+ * the extension is unknown or absent — callers must then either prompt
+ * the user (page / vsc-ext) or fall back explicitly. This never
+ * silently guesses, since a wrong guess routes bytes through the wrong
+ * parser and produces confusing error messages rather than a simple
+ * "please pick a format" prompt.
+ */
+export function inferFormatFromFilename(filename: string): FileFormat | null {
+  const ext = extensionOf(filename);
+  if (!ext) return null;
+  for (const entry of FILE_FORMAT_REGISTRY) {
+    if (entry.extensions.includes(ext)) {
+      return entry.format;
+    }
+  }
+  return null;
+}

--- a/core/src/io/index.ts
+++ b/core/src/io/index.ts
@@ -2,10 +2,18 @@ import type { Frame } from "@molcrafts/molrs";
 import type { MolvisApp as Molvis } from "../app";
 import { Trajectory } from "../system/trajectory";
 import { ensureDataSource } from "../transport/rpc/router";
-import { readFrames } from "./reader";
+import { type FileFormat, readFrames } from "./reader";
 import { loadZarrFiles } from "./zarr";
 
-export { type FileFormat, inferFormatFromFilename, readFrames } from "./reader";
+export {
+  describeFormat,
+  type FileFormat,
+  type FileFormatDescriptor,
+  FILE_FORMAT_REGISTRY,
+  getAllAcceptExtensions,
+  inferFormatFromFilename,
+  readFrames,
+} from "./reader";
 export { loadZarrFiles, type ZarrLoadResult } from "./zarr";
 export {
   defaultExtensionForFormat,
@@ -44,6 +52,7 @@ export async function loadFileContent(
   app: Molvis,
   content: FileContent,
   filename: string,
+  format?: FileFormat,
 ): Promise<void> {
   appCleanups.get(app)?.();
   appCleanups.delete(app);
@@ -54,7 +63,7 @@ export async function loadFileContent(
   let firstFrame: Frame;
 
   if (typeof content === "string") {
-    const frames = readFrames(content, filename);
+    const frames = readFrames(content, filename, format);
     const boxes = frames.map((f) => f.simbox);
     trajectory = new Trajectory(frames, boxes);
     firstFrame = frames[0];

--- a/core/src/io/reader.ts
+++ b/core/src/io/reader.ts
@@ -7,37 +7,21 @@ import {
 } from "@molcrafts/molrs";
 import { writeBackboneBlock } from "../artist/ribbon/backbone_block";
 import { logger } from "../utils/logger";
+import {
+  type FileFormat,
+  getAllAcceptExtensions,
+  inferFormatFromFilename,
+} from "./formats";
 import { normalizeAtomCoords } from "./normalize_coords";
 
-export type FileFormat = "pdb" | "xyz" | "lammps" | "lammps-dump";
-
-/**
- * Infer a file format from the filename extension. Unknown extensions
- * fall through to `fallback` (default `"pdb"`).
- */
-export function inferFormatFromFilename(
-  filename: string,
-  fallback: FileFormat = "pdb",
-): FileFormat {
-  const trimmed = filename.trim();
-  const dot = trimmed.lastIndexOf(".");
-  const ext = dot >= 0 ? trimmed.slice(dot + 1).toLowerCase() : "";
-  switch (ext) {
-    case "pdb":
-      return "pdb";
-    case "xyz":
-      return "xyz";
-    case "lammps":
-    case "lmp":
-    case "data":
-      return "lammps";
-    case "dump":
-    case "lammpstrj":
-      return "lammps-dump";
-    default:
-      return fallback;
-  }
-}
+export {
+  describeFormat,
+  type FileFormat,
+  type FileFormatDescriptor,
+  FILE_FORMAT_REGISTRY,
+  getAllAcceptExtensions,
+  inferFormatFromFilename,
+} from "./formats";
 
 interface MultiFrameReader {
   len(): number;
@@ -63,6 +47,11 @@ function openReader(content: string, format: FileFormat): MultiFrameReader {
  * return a one-element array; multi-frame formats (XYZ, LAMMPS dump) return
  * one entry per step.
  *
+ * If `format` is omitted, the extension is used to dispatch. When the
+ * extension is unrecognized and no `format` is supplied we throw, since
+ * we would otherwise be picking a parser at random. Every UI-level
+ * ingress point should catch that case and prompt the user.
+ *
  * Column names, dtypes, and `simbox` come straight from molrs — the molpy
  * convention (`element`, `x`/`y`/`z`, `atomi`/`atomj` u32) is already what
  * each reader produces. Downstream code that needs a column and does not
@@ -71,18 +60,28 @@ function openReader(content: string, format: FileFormat): MultiFrameReader {
  * PDB gets a `residues` block attached when the file describes a backbone,
  * so the ribbon renderer can dispatch on data rather than format.
  */
-export function readFrames(content: string, filename: string): Frame[] {
-  const format = inferFormatFromFilename(filename);
-  const reader = openReader(content, format);
+export function readFrames(
+  content: string,
+  filename: string,
+  format?: FileFormat,
+): Frame[] {
+  const resolved = format ?? inferFormatFromFilename(filename);
+  if (!resolved) {
+    throw new Error(
+      `Unable to detect format from filename "${filename}". ` +
+        `Supported extensions: ${getAllAcceptExtensions()}.`,
+    );
+  }
+  const reader = openReader(content, resolved);
   const frames: Frame[] = [];
   try {
     const count = reader.len();
     for (let step = 0; step < count; step++) {
       const frame = reader.read(step);
       if (!frame) {
-        throw new Error(`${format} reader returned no frame at step ${step}`);
+        throw new Error(`${resolved} reader returned no frame at step ${step}`);
       }
-      if (format === "pdb") {
+      if (resolved === "pdb") {
         writeBackboneBlock(frame, content);
       }
       normalizeAtomCoords(frame);
@@ -91,6 +90,6 @@ export function readFrames(content: string, filename: string): Frame[] {
   } finally {
     reader.free();
   }
-  logger.info(`[reader] Read ${frames.length} ${format} frame(s)`);
+  logger.info(`[reader] Read ${frames.length} ${resolved} frame(s)`);
   return frames;
 }

--- a/core/src/io/writer.ts
+++ b/core/src/io/writer.ts
@@ -73,7 +73,7 @@ export function writeFrame(
   let filename = options.filename || "structure";
 
   if (!format && filename) {
-    format = inferFormatFromFilename(filename);
+    format = inferFormatFromFilename(filename) ?? undefined;
   }
 
   if (!format) {

--- a/core/src/overlays/index.ts
+++ b/core/src/overlays/index.ts
@@ -3,12 +3,17 @@ export { Arrow3DOverlay } from "./arrow3d";
 export { Arrow2DOverlay } from "./arrow2d";
 export { TextLabelOverlay } from "./text_label";
 export { VectorFieldOverlay } from "./vector_field";
+export { MarkAtomOverlay } from "./mark_atom";
 export type {
   Overlay,
   OverlayEventMap,
   Vec3,
+  AtomAnchored,
   Arrow3DProps,
   Arrow2DProps,
   TextLabelProps,
   VectorFieldProps,
+  MarkAtomProps,
+  MarkShape,
+  MarkLabel,
 } from "./types";

--- a/core/src/overlays/mark_atom.ts
+++ b/core/src/overlays/mark_atom.ts
@@ -1,0 +1,463 @@
+/**
+ * MarkAtomOverlay — a composite overlay that marks an atom.
+ *
+ * One mark = one atom (or one world point) + an optional shape + an optional
+ * text label, managed as a single unit with a single id. Intended for
+ * annotating pSMILES / bigSMILES endpoints, reactive sites, or atoms flagged
+ * by external analyses.
+ *
+ * The shape component is a pure 3D world-space mesh (translucent sphere halo).
+ * The label component uses BabylonJS GUI and projects to screen each render
+ * frame, so updateScreenPositions() is implemented only when a label is active.
+ *
+ * Atom anchoring is routed through the shared AtomAnchored protocol — the
+ * per-frame sync dispatch in MolvisApp handles all anchored overlays uniformly.
+ */
+
+import {
+  Color3,
+  MeshBuilder,
+  StandardMaterial,
+  TransformNode,
+  Vector3,
+} from "@babylonjs/core";
+import type { Mesh, Scene } from "@babylonjs/core";
+import {
+  type AdvancedDynamicTexture,
+  Rectangle,
+  TextBlock,
+} from "@babylonjs/gui";
+import type {
+  AtomAnchored,
+  MarkAtomProps,
+  MarkLabel,
+  MarkShape,
+  Overlay,
+  Vec3,
+} from "./types";
+
+const DEFAULT_SHAPE_COLOR = "#ffd54a";
+const DEFAULT_SHAPE_OPACITY = 0.35;
+const DEFAULT_SHAPE_RADIUS = 0.6;
+const DEFAULT_SHAPE_SEGMENTS = 24;
+
+const DEFAULT_LABEL_COLOR = "white";
+const DEFAULT_LABEL_FONT_SIZE = 14;
+
+let _counter = 0;
+function nextId(): string {
+  return `mark_atom_${++_counter}`;
+}
+
+function hexToColor3(hex: string): Color3 {
+  const h = hex.replace(/^#/, "");
+  const r = Number.parseInt(h.substring(0, 2), 16) / 255;
+  const g = Number.parseInt(h.substring(2, 4), 16) / 255;
+  const b = Number.parseInt(h.substring(4, 6), 16) / 255;
+  return new Color3(r, g, b);
+}
+
+type ResolvedShape = Required<MarkShape>;
+type ResolvedLabel = Required<MarkLabel>;
+
+interface ResolvedProps {
+  position: Vec3;
+  anchorAtomId: number;
+  shape: ResolvedShape | null;
+  label: ResolvedLabel | null;
+  name: string;
+}
+
+export class MarkAtomOverlay implements Overlay, AtomAnchored {
+  readonly id: string;
+  readonly type = "mark_atom" as const;
+
+  private _props: ResolvedProps;
+  private _scene: Scene;
+  private _uiTexture: AdvancedDynamicTexture;
+
+  private _root: TransformNode;
+  private _shapeMesh: Mesh | null = null;
+  private _shapeMaterial: StandardMaterial | null = null;
+  private _labelBillboard: _LabelBillboard | null = null;
+
+  /** Current world-space center of the mark (atom pos when anchored). */
+  private _worldCenter: Vector3;
+
+  private constructor(
+    id: string,
+    props: ResolvedProps,
+    scene: Scene,
+    uiTexture: AdvancedDynamicTexture,
+  ) {
+    this.id = id;
+    this._props = props;
+    this._scene = scene;
+    this._uiTexture = uiTexture;
+    this._root = new TransformNode(`${id}_root`, scene);
+    this._worldCenter = this._initialCenter();
+    this._root.position.copyFrom(this._worldCenter);
+
+    if (props.shape) this._createShape(props.shape);
+    if (props.label) this._createLabel(props.label);
+  }
+
+  static create(
+    scene: Scene,
+    props: MarkAtomProps,
+    uiTexture: AdvancedDynamicTexture,
+  ): MarkAtomOverlay {
+    return new MarkAtomOverlay(
+      nextId(),
+      resolveDefaults(props),
+      scene,
+      uiTexture,
+    );
+  }
+
+  get props(): Readonly<ResolvedProps> {
+    return this._props;
+  }
+
+  get visible(): boolean {
+    return this._root.isEnabled();
+  }
+
+  set visible(v: boolean) {
+    this._root.setEnabled(v);
+    this._labelBillboard?.setVisible(v);
+  }
+
+  update(patch: Partial<MarkAtomProps>): this {
+    const prev = this._props;
+
+    // Shape / label nested props: undefined = keep, null = remove,
+    // object = shallow-merge onto previous so callers can patch a single field.
+    let shape: MarkShape | null;
+    if (patch.shape === undefined) shape = prev.shape;
+    else if (patch.shape === null) shape = null;
+    else shape = { ...(prev.shape ?? {}), ...patch.shape };
+
+    let label: MarkLabel | null;
+    if (patch.label === undefined) label = prev.label;
+    else if (patch.label === null) label = null;
+    else label = { ...(prev.label ?? { text: "" }), ...patch.label };
+
+    const next = resolveDefaults({
+      position: patch.position ?? prev.position,
+      anchorAtomId: patch.anchorAtomId ?? prev.anchorAtomId,
+      shape,
+      label,
+      name: patch.name ?? prev.name,
+    });
+    this._props = next;
+
+    // Anchor or position change → reseat world center.
+    const posChanged =
+      next.position[0] !== prev.position[0] ||
+      next.position[1] !== prev.position[1] ||
+      next.position[2] !== prev.position[2];
+    if (next.anchorAtomId !== prev.anchorAtomId || posChanged) {
+      this._worldCenter = this._initialCenter();
+      this._root.position.copyFrom(this._worldCenter);
+    }
+
+    this._applyShape(next.shape);
+    this._applyLabel(next.label);
+    return this;
+  }
+
+  dispose(): void {
+    this._disposeShape();
+    this._labelBillboard?.dispose();
+    this._labelBillboard = null;
+    this._root.dispose();
+  }
+
+  // ── AtomAnchored ─────────────────────────────────────────────────────────
+
+  getAnchorAtomId(): number {
+    return this._props.anchorAtomId;
+  }
+
+  syncToAtomPosition(x: number, y: number, z: number): void {
+    this._worldCenter.set(x, y, z);
+    this._root.position.copyFrom(this._worldCenter);
+  }
+
+  // ── Per-frame label projection ───────────────────────────────────────────
+
+  updateScreenPositions(): void {
+    // Only the label needs per-frame projection; the shape lives in world space.
+    this._labelBillboard?.project(this._scene, this._worldCenter);
+  }
+
+  // ── Private ──────────────────────────────────────────────────────────────
+
+  private _initialCenter(): Vector3 {
+    const { position, anchorAtomId } = this._props;
+    // When anchored, sync loop fills this in on the next frame-rendered event.
+    // Seed at origin so we do not flash at the wrong spot if the anchor is valid.
+    if (anchorAtomId >= 0) return new Vector3(0, 0, 0);
+    return new Vector3(position[0], position[1], position[2]);
+  }
+
+  private _createShape(shape: ResolvedShape): void {
+    const mat = new StandardMaterial(`${this.id}_mat`, this._scene);
+    const color = hexToColor3(shape.color);
+    mat.diffuseColor = color;
+    mat.emissiveColor = color.scale(0.4);
+    mat.alpha = shape.opacity;
+    mat.backFaceCulling = false;
+    mat.separateCullingPass = true;
+
+    const sphere = MeshBuilder.CreateSphere(
+      `${this.id}_sphere`,
+      {
+        diameter: shape.radius * 2,
+        segments: shape.segments,
+      },
+      this._scene,
+    );
+    sphere.material = mat;
+    sphere.isPickable = false;
+    sphere.parent = this._root;
+
+    this._shapeMaterial = mat;
+    this._shapeMesh = sphere;
+  }
+
+  private _disposeShape(): void {
+    if (this._shapeMesh) {
+      this._shapeMesh.dispose();
+      this._shapeMesh = null;
+    }
+    if (this._shapeMaterial) {
+      this._shapeMaterial.dispose();
+      this._shapeMaterial = null;
+    }
+  }
+
+  private _applyShape(next: ResolvedShape | null): void {
+    if (!next) {
+      this._disposeShape();
+      return;
+    }
+    // Rebuild on shape change — sphere geometry is cheap and this keeps the
+    // code paths single-flow (no partial update matrix).
+    this._disposeShape();
+    this._createShape(next);
+  }
+
+  private _createLabel(label: ResolvedLabel): void {
+    this._labelBillboard = new _LabelBillboard(
+      `${this.id}_label`,
+      label,
+      this._uiTexture,
+    );
+  }
+
+  private _applyLabel(next: ResolvedLabel | null): void {
+    if (!next) {
+      this._labelBillboard?.dispose();
+      this._labelBillboard = null;
+      return;
+    }
+    if (!this._labelBillboard) {
+      this._createLabel(next);
+      return;
+    }
+    this._labelBillboard.update(next);
+  }
+}
+
+// ── Private: label billboard (GUI-projected text) ───────────────────────────
+
+/**
+ * Tiny helper that owns the BabylonJS GUI controls for a single atom mark's
+ * text label. Internal to this module — do not export.
+ *
+ * Mirrors the projection logic of TextLabelOverlay but is scoped to a
+ * caller-supplied world anchor, so MarkAtomOverlay can drive position
+ * from its own atom-anchor sync.
+ */
+class _LabelBillboard {
+  private _uiTexture: AdvancedDynamicTexture;
+  private _props: ResolvedLabel;
+  private _id: string;
+
+  private _container: Rectangle | null = null;
+  private _textBlock: TextBlock | null = null;
+  private _visible = true;
+
+  constructor(
+    id: string,
+    props: ResolvedLabel,
+    uiTexture: AdvancedDynamicTexture,
+  ) {
+    this._id = id;
+    this._props = props;
+    this._uiTexture = uiTexture;
+    this._build();
+  }
+
+  update(next: ResolvedLabel): void {
+    const textChanged = next.text !== this._props.text;
+    const styleChanged =
+      next.color !== this._props.color ||
+      next.fontSize !== this._props.fontSize ||
+      next.background !== this._props.background;
+    this._props = next;
+
+    if (styleChanged) {
+      // Wholesale rebuild is simpler than reconciling a mixed Rectangle/TextBlock tree.
+      this._dispose();
+      this._build();
+      if (!this._visible) this.setVisible(false);
+    } else if (textChanged && this._textBlock) {
+      this._textBlock.text = next.text;
+    }
+  }
+
+  setVisible(v: boolean): void {
+    this._visible = v;
+    if (this._container) this._container.isVisible = v;
+    if (this._textBlock) this._textBlock.isVisible = v;
+  }
+
+  project(scene: Scene, center: Vector3): void {
+    if (!this._visible) return;
+    if (!this._container && !this._textBlock) return;
+
+    const camera = scene.activeCamera;
+    if (!camera) return;
+
+    const engine = scene.getEngine();
+    const width = engine.getRenderWidth();
+    const height = engine.getRenderHeight();
+    const viewportMatrix = camera.viewport.toGlobal(width, height);
+    const transformMatrix = scene.getTransformMatrix();
+
+    const { offset } = this._props;
+    const anchored = new Vector3(
+      center.x + offset[0],
+      center.y + offset[1],
+      center.z + offset[2],
+    );
+
+    const projected = Vector3.Project(
+      anchored,
+      transformMatrix,
+      transformMatrix,
+      viewportMatrix,
+    );
+
+    const control = this._container ?? this._textBlock;
+    if (control) {
+      control.left = `${projected.x - width / 2}px`;
+      control.top = `${projected.y - height / 2}px`;
+    }
+  }
+
+  dispose(): void {
+    this._dispose();
+  }
+
+  private _build(): void {
+    const { text, color, fontSize, background } = this._props;
+
+    const tb = new TextBlock(`${this._id}_tb`, text);
+    tb.color = color;
+    tb.fontSize = fontSize;
+    tb.outlineWidth = 2;
+    tb.outlineColor = "#000000";
+    tb.isHitTestVisible = false;
+    tb.textHorizontalAlignment = TextBlock.HORIZONTAL_ALIGNMENT_CENTER;
+    tb.textVerticalAlignment = TextBlock.VERTICAL_ALIGNMENT_CENTER;
+
+    if (background) {
+      const rect = new Rectangle(`${this._id}_bg`);
+      rect.background = background;
+      rect.cornerRadius = 4;
+      rect.thickness = 0;
+      rect.paddingLeft = "4px";
+      rect.paddingRight = "4px";
+      rect.paddingTop = "2px";
+      rect.paddingBottom = "2px";
+      rect.adaptHeightToChildren = true;
+      rect.adaptWidthToChildren = true;
+      rect.isHitTestVisible = false;
+      rect.addControl(tb);
+      this._uiTexture.addControl(rect);
+      this._container = rect;
+      this._textBlock = tb;
+    } else {
+      this._uiTexture.addControl(tb);
+      this._textBlock = tb;
+      this._container = null;
+    }
+  }
+
+  private _dispose(): void {
+    if (this._container) {
+      this._uiTexture.removeControl(this._container);
+      this._container.dispose();
+      this._container = null;
+    } else if (this._textBlock) {
+      this._uiTexture.removeControl(this._textBlock);
+    }
+    if (this._textBlock) {
+      this._textBlock.dispose();
+      this._textBlock = null;
+    }
+  }
+}
+
+// ── Defaults ─────────────────────────────────────────────────────────────────
+
+const DEFAULT_SHAPE: ResolvedShape = {
+  kind: "sphere",
+  color: DEFAULT_SHAPE_COLOR,
+  opacity: DEFAULT_SHAPE_OPACITY,
+  radius: DEFAULT_SHAPE_RADIUS,
+  segments: DEFAULT_SHAPE_SEGMENTS,
+};
+
+function resolveShape(
+  shape: MarkShape | null | undefined,
+): ResolvedShape | null {
+  if (shape === null) return null;
+  if (shape === undefined) return { ...DEFAULT_SHAPE };
+  return {
+    kind: shape.kind ?? DEFAULT_SHAPE.kind,
+    color: shape.color ?? DEFAULT_SHAPE.color,
+    opacity: shape.opacity ?? DEFAULT_SHAPE.opacity,
+    radius: shape.radius ?? DEFAULT_SHAPE.radius,
+    segments: shape.segments ?? DEFAULT_SHAPE.segments,
+  };
+}
+
+function resolveLabel(
+  label: MarkLabel | null | undefined,
+): ResolvedLabel | null {
+  if (label == null) return null;
+  return {
+    text: label.text,
+    color: label.color ?? DEFAULT_LABEL_COLOR,
+    fontSize: label.fontSize ?? DEFAULT_LABEL_FONT_SIZE,
+    background: label.background ?? null,
+    offset: label.offset ?? [0, 0, 0],
+  };
+}
+
+function resolveDefaults(p: MarkAtomProps): ResolvedProps {
+  return {
+    position: p.position ?? [0, 0, 0],
+    anchorAtomId: p.anchorAtomId ?? -1,
+    shape: resolveShape(p.shape),
+    label: resolveLabel(p.label),
+    name: p.name ?? "",
+  };
+}
+
+export type { MarkAtomProps };

--- a/core/src/overlays/text_label.ts
+++ b/core/src/overlays/text_label.ts
@@ -16,7 +16,7 @@ import {
   Rectangle,
   TextBlock,
 } from "@babylonjs/gui";
-import type { Overlay, TextLabelProps, Vec3 } from "./types";
+import type { AtomAnchored, Overlay, TextLabelProps, Vec3 } from "./types";
 
 const DEFAULT_COLOR = "white";
 const DEFAULT_FONT_SIZE = 14;
@@ -26,7 +26,7 @@ function nextId(): string {
   return `label_${++_counter}`;
 }
 
-export class TextLabelOverlay implements Overlay {
+export class TextLabelOverlay implements Overlay, AtomAnchored {
   readonly id: string;
   readonly type = "text_label" as const;
 
@@ -87,6 +87,10 @@ export class TextLabelOverlay implements Overlay {
     this._visible = v;
     if (this._container) this._container.isVisible = v;
     if (this._textBlock) this._textBlock.isVisible = v;
+  }
+
+  getAnchorAtomId(): number {
+    return this._props.anchorAtomId;
   }
 
   /**

--- a/core/src/overlays/types.ts
+++ b/core/src/overlays/types.ts
@@ -25,6 +25,20 @@ export interface Overlay {
   updateScreenPositions?(): void;
 }
 
+/**
+ * Optional protocol for overlays that follow an atom across frame updates.
+ *
+ * Implemented by TextLabelOverlay, MarkAtomOverlay, etc. The core
+ * dispatch loop (app.ts) duck-types on these two members — overlays that
+ * do not need atom tracking simply omit them.
+ */
+export interface AtomAnchored {
+  /** Atom index to follow. Return a negative value to disable anchoring. */
+  getAnchorAtomId(): number;
+  /** Called once per frame-rendered with the anchored atom's position. */
+  syncToAtomPosition(x: number, y: number, z: number): void;
+}
+
 /** Event map for OverlayManager. */
 export interface OverlayEventMap {
   "overlay-added": { overlay: Overlay };
@@ -101,6 +115,78 @@ export interface TextLabelProps {
   anchorAtomId?: number;
   /** Offset from anchor position in world units. Default: [0, 0, 0]. */
   offset?: Vec3;
+  /** Optional display name. */
+  name?: string;
+}
+
+// ── MarkAtom ──────────────────────────────────────────────────────────────────
+
+/**
+ * Visual shape component of a MarkAtom overlay.
+ *
+ * `kind` is reserved as an extension point — currently only `"sphere"`
+ * (translucent halo) is implemented; future kinds (ring, cube, crosshair)
+ * can be added without breaking the API.
+ */
+export interface MarkShape {
+  /** Shape kind. Default: "sphere". */
+  kind?: "sphere";
+  /** CSS hex color string. Default: "#ffd54a" (amber). */
+  color?: string;
+  /** Opacity 0–1. Default: 0.35. */
+  opacity?: number;
+  /** World-space radius. Default: 0.6. */
+  radius?: number;
+  /** Sphere tessellation segments. Default: 24. */
+  segments?: number;
+}
+
+/**
+ * Text label component of a MarkAtom overlay.
+ *
+ * Projected onto a BabylonJS GUI AdvancedDynamicTexture each frame, so the
+ * label always faces the camera and stays crisp at any zoom level.
+ */
+export interface MarkLabel {
+  /** Label text content (required when label is enabled). */
+  text: string;
+  /** CSS color. Default: "white". */
+  color?: string;
+  /** Font size in pixels. Default: 14. */
+  fontSize?: number;
+  /** Background color, or null for transparent. Default: null. */
+  background?: string | null;
+  /** World-space offset from the mark center. Default: [0, 0, 0]. */
+  offset?: Vec3;
+}
+
+/**
+ * MarkAtom — a composite overlay that marks an atom with an optional shape
+ * (e.g. a translucent halo) and/or an optional text label.
+ *
+ * Intended for annotating endpoints in pSMILES / bigSMILES, tagging reactive
+ * sites, or flagging atoms of interest from external analyses. One MarkAtom
+ * represents one marked atom, carries a single id, and can be undone as a
+ * unit — no need to keep a shape-overlay + label-overlay pair in sync.
+ *
+ * Exactly one of `position` or `anchorAtomId` should be set. If
+ * `anchorAtomId` is provided (>= 0), the mark follows that atom across
+ * frame updates and `position` is ignored; otherwise the mark is pinned
+ * to `position` in world space.
+ *
+ * `shape` and `label` are independently optional. Pass `null` to omit a
+ * component; omit the field entirely to accept the default (shape enabled
+ * with sphere defaults, label disabled).
+ */
+export interface MarkAtomProps {
+  /** World-space center. Ignored when anchorAtomId is set. */
+  position?: Vec3;
+  /** Atom index to follow across frames. Default: -1 (disabled). */
+  anchorAtomId?: number;
+  /** Shape component. Pass null to show no shape. Default: { kind: "sphere" }. */
+  shape?: MarkShape | null;
+  /** Label component. Pass null or omit to show no label. Default: null. */
+  label?: MarkLabel | null;
   /** Optional display name. */
   name?: string;
 }

--- a/core/tests/reader_helpers.test.ts
+++ b/core/tests/reader_helpers.test.ts
@@ -1,43 +1,77 @@
 import { describe, expect, it } from "@rstest/core";
-import { inferFormatFromFilename } from "../src/io/reader";
+import {
+  FILE_FORMAT_REGISTRY,
+  describeFormat,
+  getAllAcceptExtensions,
+  inferFormatFromFilename,
+} from "../src/io/formats";
 
 describe("inferFormatFromFilename", () => {
-  it("should detect PDB files", () => {
+  it("detects PDB files across common extensions", () => {
     expect(inferFormatFromFilename("protein.pdb")).toBe("pdb");
     expect(inferFormatFromFilename("MOLECULE.PDB")).toBe("pdb");
+    expect(inferFormatFromFilename("chain.ent")).toBe("pdb");
+    expect(inferFormatFromFilename("legacy.brk")).toBe("pdb");
   });
 
-  it("should detect XYZ files", () => {
+  it("detects XYZ / extended-XYZ files", () => {
     expect(inferFormatFromFilename("water.xyz")).toBe("xyz");
     expect(inferFormatFromFilename("trajectory.XYZ")).toBe("xyz");
+    expect(inferFormatFromFilename("props.extxyz")).toBe("xyz");
+    expect(inferFormatFromFilename("props.exyz")).toBe("xyz");
   });
 
-  it("should detect LAMMPS data files", () => {
+  it("detects LAMMPS data files across common extensions", () => {
     expect(inferFormatFromFilename("system.lammps")).toBe("lammps");
     expect(inferFormatFromFilename("system.lmp")).toBe("lammps");
     expect(inferFormatFromFilename("system.data")).toBe("lammps");
+    expect(inferFormatFromFilename("system.lammpsdata")).toBe("lammps");
   });
 
-  it("should detect LAMMPS dump files", () => {
+  it("detects LAMMPS dump / trajectory files", () => {
     expect(inferFormatFromFilename("traj.dump")).toBe("lammps-dump");
     expect(inferFormatFromFilename("traj.lammpstrj")).toBe("lammps-dump");
+    expect(inferFormatFromFilename("traj.lmptrj")).toBe("lammps-dump");
+    expect(inferFormatFromFilename("traj.lammpsdump")).toBe("lammps-dump");
   });
 
-  it("should fallback to default for unknown extensions", () => {
-    expect(inferFormatFromFilename("file.unknown")).toBe("pdb");
-    expect(inferFormatFromFilename("noextension")).toBe("pdb");
+  it("returns null for unknown extensions rather than guessing", () => {
+    expect(inferFormatFromFilename("file.unknown")).toBeNull();
+    expect(inferFormatFromFilename("file.gro")).toBeNull();
+    expect(inferFormatFromFilename("noextension")).toBeNull();
   });
 
-  it("should support custom fallback", () => {
-    expect(inferFormatFromFilename("file.unknown", "xyz")).toBe("xyz");
-  });
-
-  it("should handle files with spaces and dots", () => {
+  it("handles files with spaces and multiple dots", () => {
     expect(inferFormatFromFilename("my file.v2.pdb")).toBe("pdb");
     expect(inferFormatFromFilename("  trajectory.xyz  ")).toBe("xyz");
   });
 
-  it("should handle empty string", () => {
-    expect(inferFormatFromFilename("")).toBe("pdb");
+  it("returns null for empty input", () => {
+    expect(inferFormatFromFilename("")).toBeNull();
+  });
+});
+
+describe("getAllAcceptExtensions", () => {
+  it("emits a dotted comma-separated list of every registered extension", () => {
+    const result = getAllAcceptExtensions();
+    const parts = result.split(",");
+    for (const entry of FILE_FORMAT_REGISTRY) {
+      for (const ext of entry.extensions) {
+        expect(parts).toContain(`.${ext}`);
+      }
+    }
+  });
+
+  it("does not double-count extensions", () => {
+    const parts = getAllAcceptExtensions().split(",");
+    expect(new Set(parts).size).toBe(parts.length);
+  });
+});
+
+describe("describeFormat", () => {
+  it("returns the descriptor for every canonical format", () => {
+    for (const entry of FILE_FORMAT_REGISTRY) {
+      expect(describeFormat(entry.format)).toBe(entry);
+    }
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "molvis",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "molvis",
-      "version": "0.0.2",
+      "version": "0.0.4",
       "license": "BSD-3-Clause",
       "workspaces": [
         "core",
@@ -28,7 +28,7 @@
     },
     "core": {
       "name": "@molcrafts/molvis-core",
-      "version": "0.0.2",
+      "version": "0.0.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babylonjs/core": "^7.52.2",
@@ -11392,7 +11392,7 @@
       }
     },
     "page": {
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -11462,7 +11462,7 @@
     },
     "vsc-ext": {
       "name": "molvis",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@rsbuild/plugin-react": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "molvis",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "description": "interactive molecule visulization package",
   "author": "Roy Kid",
   "license": "BSD-3-Clause",

--- a/page/package.json
+++ b/page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "page",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "index.js",
   "type": "module",
   "keywords": [],

--- a/page/rsbuild.config.ts
+++ b/page/rsbuild.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
     alias: {
       "@": path.resolve(import.meta.dirname, "./src"),
       "@molvis/core": path.resolve(import.meta.dirname, "../core/src/index.ts"),
+      "@molvis/core/io/formats": path.resolve(
+        import.meta.dirname,
+        "../core/src/io/formats.ts",
+      ),
       "@molvis/core/io": path.resolve(
         import.meta.dirname,
         "../core/src/io/index.ts",

--- a/page/src/App.tsx
+++ b/page/src/App.tsx
@@ -1,5 +1,6 @@
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { TimelineControl } from "@/components/TimelineControl";
+import { FormatPickerProvider } from "@/components/format-picker-dialog";
 import {
   ResizableHandle,
   ResizablePanel,
@@ -78,18 +79,20 @@ const App: React.FC = () => {
             session: opts.session,
           }}
         >
-          <div
-            className="h-full w-full bg-background overflow-hidden"
-            onContextMenu={(e) => e.preventDefault()}
-          >
-            <MolvisWrapper onMount={setApp} />
-          </div>
-          <StateSyncDialog
-            open={stateSync.pending !== null}
-            summary={stateSync.pending?.summary ?? null}
-            onKeepLocal={stateSync.keepLocal}
-            onApplyBackend={() => void stateSync.applyBackend()}
-          />
+          <FormatPickerProvider>
+            <div
+              className="h-full w-full bg-background overflow-hidden"
+              onContextMenu={(e) => e.preventDefault()}
+            >
+              <MolvisWrapper onMount={setApp} />
+            </div>
+            <StateSyncDialog
+              open={stateSync.pending !== null}
+              summary={stateSync.pending?.summary ?? null}
+              onKeepLocal={stateSync.keepLocal}
+              onApplyBackend={() => void stateSync.applyBackend()}
+            />
+          </FormatPickerProvider>
         </BackendConnectionProvider>
       </ErrorBoundary>
     );
@@ -105,86 +108,88 @@ const App: React.FC = () => {
           session: opts.session,
         }}
       >
-        <div
-          className="h-full w-full flex flex-col bg-background text-foreground overflow-hidden"
-          onContextMenu={(e) => e.preventDefault()}
-        >
-          <TopBar app={app} currentMode={currentMode} />
-
-          <ResizablePanelGroup
-            orientation="horizontal"
-            className="flex-1"
-            defaultLayout={{ left: 0, canvas: 79, right: 21 }}
-            resizeTargetMinimumSize={{ fine: 20, coarse: 36 }}
-          >
-            <ResizablePanel
-              id="left"
-              defaultSize="0%"
-              collapsible={true}
-              collapsedSize="0%"
-              minSize="14%"
-              maxSize="38%"
-              className="bg-background flex flex-col min-w-0"
-            >
-              <LeftSidebar app={app} />
-            </ResizablePanel>
-
-            <ResizableHandle withHandle />
-
-            <ResizablePanel
-              id="canvas"
-              defaultSize="79%"
-              minSize="35%"
-              className="flex flex-col min-w-[360px]"
-            >
-              <div className="flex-1 relative bg-muted/20 overflow-hidden">
-                <MolvisWrapper onMount={setApp} />
-              </div>
-
-              {app && trajectoryLength > 1 && (
-                <div className="h-9 border-t bg-muted/20 shrink-0 z-10">
-                  <TimelineControl app={app} totalFrames={trajectoryLength} />
-                </div>
-              )}
-            </ResizablePanel>
-
-            <ResizableHandle withHandle />
-
-            <ResizablePanel
-              id="right"
-              defaultSize="21%"
-              minSize="14%"
-              maxSize="40%"
-              collapsible={true}
-              collapsedSize="0%"
-              className="bg-background flex flex-col min-w-0"
-            >
-              <RightSidebar
-                app={app}
-                currentMode={currentMode}
-                onModeChange={handleModeSwitch}
-              />
-            </ResizablePanel>
-          </ResizablePanelGroup>
-
+        <FormatPickerProvider>
           <div
-            className={`h-4 border-t bg-muted/60 flex items-center px-2 text-[9px] shrink-0 ${statusType === "error" ? "text-red-500 font-bold bg-red-100/10" : "text-muted-foreground"}`}
+            className="h-full w-full flex flex-col bg-background text-foreground overflow-hidden"
+            onContextMenu={(e) => e.preventDefault()}
           >
-            {statusMessage}
+            <TopBar app={app} currentMode={currentMode} />
+
+            <ResizablePanelGroup
+              orientation="horizontal"
+              className="flex-1"
+              defaultLayout={{ left: 0, canvas: 79, right: 21 }}
+              resizeTargetMinimumSize={{ fine: 20, coarse: 36 }}
+            >
+              <ResizablePanel
+                id="left"
+                defaultSize="0%"
+                collapsible={true}
+                collapsedSize="0%"
+                minSize="14%"
+                maxSize="38%"
+                className="bg-background flex flex-col min-w-0"
+              >
+                <LeftSidebar app={app} />
+              </ResizablePanel>
+
+              <ResizableHandle withHandle />
+
+              <ResizablePanel
+                id="canvas"
+                defaultSize="79%"
+                minSize="35%"
+                className="flex flex-col min-w-[360px]"
+              >
+                <div className="flex-1 relative bg-muted/20 overflow-hidden">
+                  <MolvisWrapper onMount={setApp} />
+                </div>
+
+                {app && trajectoryLength > 1 && (
+                  <div className="h-9 border-t bg-muted/20 shrink-0 z-10">
+                    <TimelineControl app={app} totalFrames={trajectoryLength} />
+                  </div>
+                )}
+              </ResizablePanel>
+
+              <ResizableHandle withHandle />
+
+              <ResizablePanel
+                id="right"
+                defaultSize="21%"
+                minSize="14%"
+                maxSize="40%"
+                collapsible={true}
+                collapsedSize="0%"
+                className="bg-background flex flex-col min-w-0"
+              >
+                <RightSidebar
+                  app={app}
+                  currentMode={currentMode}
+                  onModeChange={handleModeSwitch}
+                />
+              </ResizablePanel>
+            </ResizablePanelGroup>
+
+            <div
+              className={`h-4 border-t bg-muted/60 flex items-center px-2 text-[9px] shrink-0 ${statusType === "error" ? "text-red-500 font-bold bg-red-100/10" : "text-muted-foreground"}`}
+            >
+              {statusMessage}
+            </div>
+
+            <KeyboardShortcutsDialog
+              open={shortcutsOpen}
+              onOpenChange={setShortcutsOpen}
+            />
+
+            <StateSyncDialog
+              open={stateSync.pending !== null}
+              summary={stateSync.pending?.summary ?? null}
+              onKeepLocal={stateSync.keepLocal}
+              onApplyBackend={() => void stateSync.applyBackend()}
+            />
           </div>
-
-          <KeyboardShortcutsDialog
-            open={shortcutsOpen}
-            onOpenChange={setShortcutsOpen}
-          />
-
-          <StateSyncDialog
-            open={stateSync.pending !== null}
-            summary={stateSync.pending?.summary ?? null}
-            onKeepLocal={stateSync.keepLocal}
-            onApplyBackend={() => void stateSync.applyBackend()}
-          />
-        </div>
+        </FormatPickerProvider>
       </BackendConnectionProvider>
     </ErrorBoundary>
   );

--- a/page/src/MolvisWrapper.tsx
+++ b/page/src/MolvisWrapper.tsx
@@ -1,11 +1,14 @@
 import {
+  loadFileWithFormatPrompt,
+  useFormatPicker,
+} from "@/components/format-picker-dialog";
+import {
   type Molvis,
   type MolvisConfig,
   type MolvisSetting,
   defaultMolvisConfig,
   mountMolvis,
 } from "@molvis/core";
-import { loadFileContent } from "@molvis/core/io";
 import type React from "react";
 import { useEffect, useRef } from "react";
 
@@ -108,6 +111,9 @@ function applyMolvisSettings(
 const MolvisWrapper: React.FC<MolvisWrapperProps> = ({ onMount }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const molvisRef = useRef<Molvis | null>(null);
+  const pickFormat = useFormatPicker();
+  const pickFormatRef = useRef(pickFormat);
+  pickFormatRef.current = pickFormat;
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -244,7 +250,18 @@ const MolvisWrapper: React.FC<MolvisWrapperProps> = ({ onMount }) => {
       if (!file || !molvisRef.current) return;
       try {
         const content = await file.text();
-        await loadFileContent(molvisRef.current, content, file.name);
+        const started = await loadFileWithFormatPrompt(
+          molvisRef.current,
+          content,
+          file.name,
+          pickFormatRef.current,
+        );
+        if (!started) {
+          molvisRef.current.events.emit("status-message", {
+            text: `Cancelled loading ${file.name}`,
+            type: "info",
+          });
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         molvisRef.current.events.emit("status-message", {

--- a/page/src/components/format-picker-dialog.tsx
+++ b/page/src/components/format-picker-dialog.tsx
@@ -1,0 +1,195 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { Molvis } from "@molvis/core";
+import {
+  FILE_FORMAT_REGISTRY,
+  type FileFormat,
+  inferFormatFromFilename,
+  loadFileContent,
+} from "@molvis/core/io";
+import {
+  type ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+type PickerReason = "unknown-extension" | "no-extension";
+
+interface PickerState {
+  filename: string;
+  reason: PickerReason;
+}
+
+type PickFormat = (
+  filename: string,
+  reason: PickerReason,
+) => Promise<FileFormat | null>;
+
+const FormatPickerContext = createContext<PickFormat | null>(null);
+
+/**
+ * Provides a single shared format-picker dialog to the rest of the app.
+ * Any consumer can call `useFormatPicker()` to get an async
+ * `pickFormat(filename, reason)` that resolves with the user's pick
+ * (or `null` on cancel). The dialog itself is mounted once at the
+ * provider root so every ingress point uses the same modal.
+ */
+export const FormatPickerProvider: React.FC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  const [state, setState] = useState<PickerState | null>(null);
+  const resolverRef = useRef<((format: FileFormat | null) => void) | null>(
+    null,
+  );
+
+  const close = useCallback((format: FileFormat | null) => {
+    const resolve = resolverRef.current;
+    resolverRef.current = null;
+    setState(null);
+    resolve?.(format);
+  }, []);
+
+  const pickFormat = useCallback<PickFormat>((filename, reason) => {
+    return new Promise<FileFormat | null>((resolve) => {
+      resolverRef.current?.(null);
+      resolverRef.current = resolve;
+      setState({ filename, reason });
+    });
+  }, []);
+
+  return (
+    <FormatPickerContext.Provider value={pickFormat}>
+      {children}
+      {state && (
+        <FormatPickerDialog
+          filename={state.filename}
+          reason={state.reason}
+          onPick={(format) => close(format)}
+          onCancel={() => close(null)}
+        />
+      )}
+    </FormatPickerContext.Provider>
+  );
+};
+
+/**
+ * Returns the `pickFormat(filename, reason)` helper. Throws if called
+ * outside a `<FormatPickerProvider>` — that is by design so a silent
+ * fallback never reintroduces the old "guess pdb" behavior.
+ */
+export function useFormatPicker(): PickFormat {
+  const value = useContext(FormatPickerContext);
+  if (!value) {
+    throw new Error(
+      "useFormatPicker must be used within <FormatPickerProvider>",
+    );
+  }
+  return value;
+}
+
+/**
+ * Resolve a FileFormat for `filename` (by extension, otherwise by prompting
+ * the user) and call `loadFileContent`. Returns `true` if the load began,
+ * `false` if the user cancelled the picker.
+ */
+export async function loadFileWithFormatPrompt(
+  app: Molvis,
+  content: string | Record<string, string>,
+  filename: string,
+  pickFormat: PickFormat,
+): Promise<boolean> {
+  if (typeof content !== "string") {
+    await loadFileContent(app, content, filename);
+    return true;
+  }
+
+  const inferred = inferFormatFromFilename(filename);
+  if (inferred) {
+    await loadFileContent(app, content, filename, inferred);
+    return true;
+  }
+
+  const reason = filename.includes(".") ? "unknown-extension" : "no-extension";
+  const picked = await pickFormat(filename, reason);
+  if (!picked) {
+    return false;
+  }
+  await loadFileContent(app, content, filename, picked);
+  return true;
+}
+
+interface FormatPickerDialogProps {
+  filename: string;
+  reason: PickerReason;
+  onPick: (format: FileFormat) => void;
+  onCancel: () => void;
+}
+
+const FormatPickerDialog: React.FC<FormatPickerDialogProps> = ({
+  filename,
+  reason,
+  onPick,
+  onCancel,
+}) => {
+  const title =
+    reason === "no-extension"
+      ? "File has no extension"
+      : "Unrecognized file extension";
+  const describe = useMemo(
+    () =>
+      reason === "no-extension"
+        ? `MolVis couldn't infer a format because "${filename}" has no extension. Pick a parser below.`
+        : `MolVis doesn't recognize the extension of "${filename}". Pick the parser you'd like to use.`,
+    [filename, reason],
+  );
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onCancel()}>
+      <DialogContent className="max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{describe}</DialogDescription>
+        </DialogHeader>
+
+        <ul className="space-y-1.5">
+          {FILE_FORMAT_REGISTRY.map((entry) => (
+            <li key={entry.format}>
+              <button
+                type="button"
+                onClick={() => onPick(entry.format)}
+                className="w-full text-left border rounded-md px-3 py-2 hover:bg-muted/50 focus:outline-none focus:ring-2 focus:ring-ring transition-colors"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-sm font-medium">{entry.label}</span>
+                  <span className="text-[10px] font-mono text-muted-foreground">
+                    {entry.extensions.map((e) => `.${e}`).join(" ")}
+                  </span>
+                </div>
+                <div className="text-[10px] text-muted-foreground mt-0.5">
+                  {entry.description}
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+
+        <DialogFooter>
+          <Button variant="outline" size="sm" onClick={onCancel}>
+            Cancel
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/page/src/ui/layout/ExportDialog.tsx
+++ b/page/src/ui/layout/ExportDialog.tsx
@@ -36,7 +36,7 @@ export const ExportDialog: React.FC<ExportDialogProps> = ({ app }) => {
     setIsExporting(true);
 
     try {
-      const format = inferFormatFromFilename(filename, "pdb");
+      const format = inferFormatFromFilename(filename) ?? "pdb";
       const payload = exportFrame(app.world.sceneIndex, { format, filename });
 
       if (!payload.content) {

--- a/page/src/ui/modes/view/modifiers/DataSourceModifier.tsx
+++ b/page/src/ui/modes/view/modifiers/DataSourceModifier.tsx
@@ -1,3 +1,7 @@
+import {
+  loadFileWithFormatPrompt,
+  useFormatPicker,
+} from "@/components/format-picker-dialog";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -6,7 +10,7 @@ import {
   type Molvis,
   Trajectory,
 } from "@molvis/core";
-import { loadFileContent } from "@molvis/core/io";
+import { getAllAcceptExtensions } from "@molvis/core/io";
 import { FileUp, Trash2 } from "lucide-react";
 import type React from "react";
 
@@ -21,14 +25,28 @@ export const DataSourceModifier: React.FC<DataSourceModifierProps> = ({
   app,
   onUpdate,
 }) => {
+  const pickFormat = useFormatPicker();
+
   const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file || !app) return;
 
     try {
       const content = await file.text();
-      await loadFileContent(app, content, file.name);
-      onUpdate();
+      const started = await loadFileWithFormatPrompt(
+        app,
+        content,
+        file.name,
+        pickFormat,
+      );
+      if (started) {
+        onUpdate();
+      } else {
+        app.events.emit("status-message", {
+          text: `Cancelled loading ${file.name}`,
+          type: "info",
+        });
+      }
     } catch (err) {
       app.events.emit("status-message", {
         text: `Failed to load file: ${err instanceof Error ? err.message : String(err)}`,
@@ -72,7 +90,7 @@ export const DataSourceModifier: React.FC<DataSourceModifierProps> = ({
             type="file"
             className="absolute inset-0 opacity-0 cursor-pointer"
             onChange={handleFileUpload}
-            accept=".pdb,.xyz,.lmp,.lammps"
+            accept={getAllAcceptExtensions()}
             title="Load file"
             aria-label="Load file"
           />

--- a/page/tsconfig.json
+++ b/page/tsconfig.json
@@ -6,7 +6,8 @@
     "paths": {
       "@/*": ["./src/*"],
       "@molvis/core": ["../core/src/index.ts"],
-      "@molvis/core/io": ["../core/src/io/index.ts"]
+      "@molvis/core/io": ["../core/src/io/index.ts"],
+      "@molvis/core/io/formats": ["../core/src/io/formats.ts"]
     }
   },
   "include": ["src"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "molcrafts-molvis"
-version = "0.0.3"
+version = "0.0.4"
 description = "Molecular visualization driven by a local WebSocket-hosted page"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/src/molvis/__init__.py
+++ b/python/src/molvis/__init__.py
@@ -61,4 +61,4 @@ __all__ = [
     "render_palette_preview",
     "save_palette_preview_bytes",
 ]
-__version__ = "0.0.1"
+__version__ = "0.0.4"

--- a/vsc-ext/package.json
+++ b/vsc-ext/package.json
@@ -12,7 +12,7 @@
   },
   "license": "BSD-3-Clause",
   "icon": "image/molvis-icon.png",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "engines": {
     "vscode": "^1.108.1"
   },

--- a/vsc-ext/rslib.extension.config.ts
+++ b/vsc-ext/rslib.extension.config.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { defineConfig } from "@rslib/core";
 
 const sharedDefine = {
@@ -26,4 +27,13 @@ export default defineConfig({
       },
     },
   ],
+
+  resolve: {
+    alias: {
+      "@molvis/core/io/formats": path.resolve(
+        import.meta.dirname,
+        "../core/src/io/formats.ts",
+      ),
+    },
+  },
 });

--- a/vsc-ext/rslib.webview.config.ts
+++ b/vsc-ext/rslib.webview.config.ts
@@ -44,6 +44,10 @@ export default defineConfig({
   resolve: {
     alias: {
       "@molvis/core": path.resolve(import.meta.dirname, "../core/src/index.ts"),
+      "@molvis/core/io/formats": path.resolve(
+        import.meta.dirname,
+        "../core/src/io/formats.ts",
+      ),
       "@molvis/core/io": path.resolve(
         import.meta.dirname,
         "../core/src/io/index.ts",

--- a/vsc-ext/src/extension/loading/formatResolver.ts
+++ b/vsc-ext/src/extension/loading/formatResolver.ts
@@ -1,0 +1,41 @@
+import {
+  FILE_FORMAT_REGISTRY,
+  inferFormatFromFilename,
+} from "@molvis/core/io/formats";
+import * as vscode from "vscode";
+import type { MolecularFileFormat } from "../types";
+
+/**
+ * Resolve a molecular file format for `filename`. Returns the inferred
+ * format when the extension matches the registry; otherwise shows a
+ * VS Code quick pick so the user can choose. Returns `null` when the
+ * user dismisses the picker, which callers should treat as "do not
+ * load the file".
+ *
+ * Zarr payloads are detected by path / stat upstream and never reach
+ * this helper, so we don't list a Zarr option here.
+ */
+export async function resolveFileFormat(
+  filename: string,
+): Promise<MolecularFileFormat | null> {
+  const inferred = inferFormatFromFilename(filename);
+  if (inferred) return inferred as MolecularFileFormat;
+
+  const items: Array<vscode.QuickPickItem & { format: MolecularFileFormat }> =
+    FILE_FORMAT_REGISTRY.map((entry) => ({
+      label: entry.label,
+      description: entry.extensions.map((e) => `.${e}`).join(" "),
+      detail: entry.description,
+      format: entry.format as MolecularFileFormat,
+    }));
+
+  const picked = await vscode.window.showQuickPick(items, {
+    title: `Pick a format for "${filename}"`,
+    placeHolder: "MolVis couldn't infer a format from the extension",
+    matchOnDescription: true,
+    matchOnDetail: true,
+    ignoreFocusOut: true,
+  });
+
+  return picked?.format ?? null;
+}

--- a/vsc-ext/src/extension/panels/messaging.ts
+++ b/vsc-ext/src/extension/panels/messaging.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { resolveFileFormat } from "../loading/formatResolver";
 import type { MolecularFileLoader } from "../loading/molecularFileLoader";
 import { getDisplayName } from "../loading/pathUtils";
 import type {
@@ -25,10 +26,23 @@ export async function sendLoadedFile(
 ): Promise<void> {
   try {
     const loaded = await fileLoader.load(uri);
+    // Zarr directory payloads are typed — the `Record` variant never
+    // needs a format hint because the reader dispatches on payload shape.
+    const format =
+      typeof loaded.payload === "string"
+        ? await resolveFileFormat(loaded.filename)
+        : null;
+    if (typeof loaded.payload === "string" && !format) {
+      logger.info(
+        `MolVis: user cancelled format picker for ${loaded.filename}`,
+      );
+      return;
+    }
     sendToWebview(webview, {
       type: "loadFile",
       content: loaded.payload,
       filename: loaded.filename,
+      ...(format ? { format } : {}),
     });
   } catch (error) {
     logger.error(`MolVis: Failed to load file: ${error}`);
@@ -80,11 +94,19 @@ export async function handleSaveFile(
 export async function loadTextDocumentToWebview(
   webview: vscode.Webview,
   document: vscode.TextDocument,
+  logger?: Logger,
 ): Promise<void> {
+  const filename = getDisplayName(document.uri);
+  const format = await resolveFileFormat(filename);
+  if (!format) {
+    logger?.info(`MolVis: user cancelled format picker for ${filename}`);
+    return;
+  }
   sendToWebview(webview, {
     type: "loadFile",
     content: document.getText(),
-    filename: getDisplayName(document.uri),
+    filename,
+    format,
   });
 }
 

--- a/vsc-ext/src/extension/types.ts
+++ b/vsc-ext/src/extension/types.ts
@@ -43,6 +43,13 @@ export class VsCodeLogger implements Logger, vscode.Disposable {
 
 export type MolecularFilePayload = string | Record<string, string>;
 
+/**
+ * String identifier for a molecular file format. Mirrors `FileFormat`
+ * from `@molvis/core/io/formats`; we re-declare it here so the
+ * extension host doesn't depend on core's type exports transitively.
+ */
+export type MolecularFileFormat = "pdb" | "xyz" | "lammps" | "lammps-dump";
+
 export type HostToWebviewMessage =
   | {
       type: "init";
@@ -51,7 +58,12 @@ export type HostToWebviewMessage =
       settings?: unknown;
     }
   | { type: "applySettings"; config?: unknown; settings?: unknown }
-  | { type: "loadFile"; content: MolecularFilePayload; filename: string }
+  | {
+      type: "loadFile";
+      content: MolecularFilePayload;
+      filename: string;
+      format?: MolecularFileFormat;
+    }
   | { type: "triggerSave" }
   | { type: "error"; message: string };
 

--- a/vsc-ext/src/webview/controller.ts
+++ b/vsc-ext/src/webview/controller.ts
@@ -102,9 +102,9 @@ export function bootstrapWebview(container: HTMLElement): void {
         }
         break;
       case "loadFile": {
-        const { content, filename } = message;
+        const { content, filename, format } = message;
         runAsync(vscode, `Failed to load ${filename}`, () =>
-          loadFileContent(app, content, filename),
+          loadFileContent(app, content, filename, format),
         );
         break;
       }
@@ -132,7 +132,7 @@ export function bootstrapWebview(container: HTMLElement): void {
   app.events.on("export-requested", () => {
     runAsync(vscode, "Failed to export scene", async () => {
       const suggestedName = "molvis.pdb";
-      const format = inferFormatFromFilename(suggestedName, "pdb");
+      const format = inferFormatFromFilename(suggestedName) ?? "pdb";
       const payload = exportFrame(app.world.sceneIndex, {
         format,
         filename: suggestedName,

--- a/vsc-ext/tsconfig.json
+++ b/vsc-ext/tsconfig.json
@@ -7,6 +7,7 @@
     "paths": {
       "@molvis/core": ["../core/src/index.ts"],
       "@molvis/core/io": ["../core/src/io/index.ts"],
+      "@molvis/core/io/formats": ["../core/src/io/formats.ts"],
       "@/*": ["../page/src/*"]
     }
   },


### PR DESCRIPTION
## Context

The v0.0.4 release (#16) successfully shipped `molcrafts-molvis` to PyPI and `molcrafts.molvis` to VS Marketplace, but **`@molcrafts/molvis-core@0.0.4` to npm failed** at the `npm install -g npm@latest` step with:

\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
\`\`\`

Retry didn't help — the error is deterministic on every runner that pulls Node 22.22.2 from hostedtoolcache.

## Root cause (not ours)

Known bug in the npm 10.9.7 bundled with Node 22.22.2 — the tarball is missing `promise-retry`, a dependency of `@npmcli/arborist`, so the shipped npm can't run `install` at all. Public issues confirming this:
- [actions/runner-images#13883](https://github.com/actions/runner-images/issues/13883) — "npm in Node.js 22.22.2 toolcache has broken module tree (missing \`promise-retry\`)"
- [nodejs/node#62425](https://github.com/nodejs/node/issues/62425), [nodejs/node#62430](https://github.com/nodejs/node/issues/62430)
- [npm/cli#9151](https://github.com/npm/cli/issues/9151) — same bug on nvm + \`node:22\` Docker images
- [heroku/heroku-buildpack-nodejs#1590](https://github.com/heroku/heroku-buildpack-nodejs/issues/1590)

Every linked issue's recommended workaround is the same: use corepack.

## Fix

- Replace \`npm install -g npm@latest\` with \`corepack enable && corepack prepare npm@11.5.1 --activate\`. Corepack is built into Node ≥16, pulls the requested npm version directly from the registry, and completely bypasses the broken shipped npm.
- Pin to npm 11.5.1 explicitly (the minimum for OIDC Trusted Publishing) rather than tracking \`@latest\`, so we don't re-enter this class of bug if a future \`@latest\` ships with a different regression.
- Add \`workflow_dispatch:\` to the trigger list. This lets us re-fire the publish workflow after a fix without needing to delete/recreate release tags. Once this PR lands, the v0.0.4 npm publish can be retried with \`gh workflow run release-core.yml --repo MolCrafts/molvis --ref master\`.

## Test plan

- [x] \`.github/workflows/release-core.yml\` still valid YAML (parsed by GH)
- [ ] After merge: fire \`gh workflow run release-core.yml --ref master\`
- [ ] Verify \`@molcrafts/molvis-core@0.0.4\` appears on npm