### PR TITLE
ci(release-core): upgrade Node to 24 LTS (real fix for npm OIDC 404)

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -17,23 +17,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Node 24 LTS ships with npm 11.5+ natively, which is the minimum
+      # version that supports OIDC Trusted Publishing's registry-side
+      # handshake. On Node 22 the bundled npm is 10.9.7; `npm publish`
+      # cannot complete the handshake and the registry treats the request
+      # as anonymous, returning a misleading `404 "is not in this registry"`
+      # on the PUT. Moving to Node 24 avoids both that and the separate
+      # hostedtoolcache regression on Node 22.22.2 (broken shipped npm
+      # missing `promise-retry`, which defeats any attempt to upgrade
+      # via `npm install -g npm@latest` or `corepack prepare --activate`).
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           registry-url: https://registry.npmjs.org
-
-      # Trusted Publishing (OIDC) requires npm >= 11.5.1, but the npm bundled
-      # with the Node 22 hostedtoolcache image has been shipping with a broken
-      # node_modules tree (missing `promise-retry` in arborist), which makes
-      # `npm install -g npm@latest` fail before it can upgrade itself.
-      # Using corepack sidesteps the broken shipped npm — it downloads and
-      # activates the requested npm version directly.
-      - name: Install npm 11 via corepack
-        run: |
-          corepack enable
-          corepack prepare npm@11.5.1 --activate
-          npm --version
 
       - run: npm ci
 


### PR DESCRIPTION
## Why

PR #17 replaced \`npm install -g npm@latest\` with \`corepack enable && corepack prepare npm@11.5.1 --activate\`. Corepack *said* it was preparing npm 11.5.1 — but in [run 24663169282](https://github.com/MolCrafts/molvis/actions/runs/24663169282) the subsequent \`npm --version\` still reported **10.9.7**. \`corepack enable\` only shims yarn and pnpm by default; npm is special-cased and \`prepare --activate\` does not swap the PATH. So \`npm publish\` was still running the 10.9.7 bundled with Node 22, which cannot complete the OIDC Trusted Publishing registry-side handshake. The registry treats the request as anonymous and returns a misleading \`404 "is not in this registry"\` on PUT.

Documented in [this Medium post](https://medium.com/@kenricktan11/npm-trusted-publishers-the-weird-404-error-and-the-node-js-24-fix-a9f1d717a5dd) — the title literally says "The Weird 404 Error and the Node.js 24 Fix".

## The fix

Upgrade to Node 24 LTS, which ships with npm 11.5+ natively. Drop the corepack step and the \`npm install -g\` step entirely — not needed. This also avoids the unrelated Node 22.22.2 hostedtoolcache regression (missing \`promise-retry\`) that failed the original v0.0.4 publish.

## Test plan

- [ ] After merge: \`gh workflow run release-core.yml --repo MolCrafts/molvis --ref master\`
- [ ] Verify \`@molcrafts/molvis-core@0.0.4\` on npm with \`npm view @molcrafts/molvis-core@0.0.4\`