### PR TITLE
chore: reconcile package-lock.json with workspace package.jsons (unblocks npm 11)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3418,6 +3418,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
@@ -10825,6 +10835,13 @@
         "node": ">=20.18.1"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unicorn-magic": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
@@ -11434,19 +11451,6 @@
         "typescript": "^5.9.3"
       }
     },
-    "page/node_modules/@types/node": {
-      "version": "25.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.18.0"
-      }
-    },
-    "page/node_modules/undici-types": {
-      "version": "7.18.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "python": {
       "name": "@molvis/python",
       "version": "0.0.2",
@@ -11488,19 +11492,6 @@
       "engines": {
         "vscode": "^1.108.1"
       }
-    },
-    "vsc-ext/node_modules/@types/node": {
-      "version": "22.19.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "vsc-ext/node_modules/undici-types": {
-      "version": "6.21.0",
-      "dev": true,
-      "license": "MIT"
     }
   }
 }


### PR DESCRIPTION
## Why

After #18 switched the release-core workflow to Node 24 (which ships npm 11), \`npm ci\` in [run 24664999167](https://github.com/MolCrafts/molvis/actions/runs/24664999167) died with:

\`\`\`
npm error code EUSAGE
npm error \`npm ci\` can only install packages when your package.json
npm error and package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: @types/node@25.6.0 from lock file
npm error Missing: undici-types@7.19.2 from lock file
\`\`\`

Root cause: pre-existing lockfile drift. \`vsc-ext/package.json\` declares \`@types/node: ^25.3.2\`, but the lockfile pinned \`vsc-ext/node_modules/@types/node\` at \`22.19.7\` — doesn't satisfy the range. npm 10 (Node 22) silently let it slide; npm 11 (Node 24) abort-on-lockfile-mismatch by design.

This has nothing to do with the Node 24 upgrade itself — the drift was already in the tree. Node 24 just surfaces it.

## The fix

Regenerate \`package-lock.json\` with npm 11:

\`\`\`
corepack prepare npm@11.11.0 --activate
npm install
\`\`\`

Result:
- \`@types/node@25.6.0\` hoisted to root (both page and vsc-ext request \`^25.3.2\` → dedupe)
- \`undici-types@7.19.2\` hoisted accordingly
- Three stale per-workspace \`@types/node\` + \`undici-types\` entries dropped

Net change: -9 lines in \`package-lock.json\`. No \`package.json\` touched.

## Test plan

- [x] \`npm ci\` succeeds locally with npm 11
- [ ] After merge: \`gh workflow run release-core.yml --repo MolCrafts/molvis --ref master\`
- [ ] Verify \`@molcrafts/molvis-core@0.0.4\` on npm