### PR TITLE
fix(core): add repository/homepage/bugs to package.json

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -16,6 +16,15 @@
       "import": "./dist/io/formats.js"
     }
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MolCrafts/molvis.git",
+    "directory": "core"
+  },
+  "homepage": "https://github.com/MolCrafts/molvis#readme",
+  "bugs": {
+    "url": "https://github.com/MolCrafts/molvis/issues"
+  },
   "files": ["dist", "README.md", "LICENSE"],
   "sideEffects": ["./src/commands/*.ts"],
   "scripts": {


### PR DESCRIPTION
## Summary
- Adds `repository`, `homepage`, and `bugs` fields to `core/package.json` so npm Trusted Publishing's sigstore provenance check can validate the upload.

## Why
The v0.0.5 npm core release ([run 24958572913](https://github.com/MolCrafts/molvis/actions/runs/24958572913)) failed with:

\`\`\`
422 Unprocessable Entity ... Error verifying sigstore provenance bundle:
package.json: "repository.url" is "", expected to match "https://github.com/MolCrafts/molvis"
\`\`\`

Without the field, the comparison value was \`""\` and provenance validation rejected the upload. PyPI and VS Marketplace v0.0.5 published successfully — only npm core was blocked.

## Plan after merge
\`workflow_dispatch\` on \`release-core.yml\`. The workflow uses the default branch ref, so it picks up this fix even though the v0.0.5 tag points to the old commit. Pure metadata fix; runtime is unchanged.

## Test plan
- [x] Biome lint passes
- [x] Core tests pass (pre-commit hook)
- [ ] After merge: re-run \`release-core.yml\` and confirm \`@molcrafts/molvis-core@0.0.5\` lands on npm