### PR TITLE
feat(page): version badge with changelog dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to MolVis are documented here. The whole repo is
+version-locked to one tag, so this is the single changelog for the core
+engine, the web page, the VSCode extension, and the Python package.
+
+This file is the source of truth for the in-app "What's new" dialog — the
+page reads it at build time (see `page/src/lib/changelog.ts`). Keep the
+format below: `## [version] - date`, then `### Section` groups, then
+`- bullet` items.
+
+## [0.0.7] - 2026-05-30
+
+### Core
+- Bump @molcrafts/molrs to 0.0.14
+- Model volumetric grids as blocks (Cube / CHGCAR readers)
+- IO / overlay / runtime cleanup after core review
+
+### UI
+- Version badge in the top bar opens this changelog
+- Translucent overlays no longer hide atoms underneath
+
+## [0.0.6] - 2026-05-20
+
+### Core
+- Add repository / homepage / bugs metadata to package.json
+- Core review remediation pass

--- a/page/rsbuild.config.ts
+++ b/page/rsbuild.config.ts
@@ -68,6 +68,10 @@ export default defineConfig({
   },
   tools: {
     rspack: {
+      // Inline the raw text of `?raw` imports (e.g. CHANGELOG.md) as a string.
+      module: {
+        rules: [{ resourceQuery: /raw/, type: "asset/source" }],
+      },
       node: {
         // kekule.js uses __dirname internally — mock it silently
         __dirname: "mock",

--- a/page/src/css.d.ts
+++ b/page/src/css.d.ts
@@ -6,3 +6,11 @@
 // modules. This file is also pulled into the vsc-ext program (its tsconfig
 // includes `../page/src/**/*.d.ts`), covering the webview's CSS imports too.
 declare module "*.css";
+
+// Raw text imports (rsbuild/rspack `?raw` query) — the file's content is
+// inlined as a string at build time. Used to read CHANGELOG.md at compile
+// time so release notes have a single human-editable source of truth.
+declare module "*?raw" {
+  const content: string;
+  export default content;
+}

--- a/page/src/lib/changelog.ts
+++ b/page/src/lib/changelog.ts
@@ -1,0 +1,78 @@
+// The project CHANGELOG is the single source of truth for release notes.
+// rsbuild/rspack inlines its raw text at build time via the `?raw` query,
+// and we parse it here into the structured form the dialog renders. Editing
+// the markdown is all that's needed to update the in-app "What's new".
+import changelogRaw from "../../../CHANGELOG.md?raw";
+
+export interface ChangelogSection {
+  /** Group label from a `### Heading`, e.g. "Core", "UI". */
+  title: string;
+  /** One entry per `- bullet` line. */
+  items: string[];
+}
+
+export interface ChangelogEntry {
+  version: string;
+  /** Date string after the version heading's ` - `, if present. */
+  date?: string;
+  sections: ChangelogSection[];
+}
+
+// `## [0.0.7] - 2026-05-30` or `## 0.0.7` — brackets and date are optional.
+// The `\s+` after `##` rejects `###` section headings (next char is `#`).
+const VERSION_HEADING = /^##\s+\[?([^\]\s]+)\]?(?:\s*[-–—]\s*(.+?))?\s*$/;
+const SECTION_HEADING = /^###\s+(.+?)\s*$/;
+const BULLET = /^[-*]\s+(.+?)\s*$/;
+
+/**
+ * Parse a Keep-a-Changelog style markdown document into release entries.
+ *
+ * Pure: builds and returns fresh objects, never mutates its input. Lines
+ * before the first version heading (title, intro prose) are ignored, as is
+ * any non-heading, non-bullet content.
+ */
+export function parseChangelog(raw: string): ChangelogEntry[] {
+  const entries: ChangelogEntry[] = [];
+  let entry: ChangelogEntry | null = null;
+  let section: ChangelogSection | null = null;
+
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const version = VERSION_HEADING.exec(trimmed);
+    if (version) {
+      entry = { version: version[1], date: version[2], sections: [] };
+      section = null;
+      entries.push(entry);
+      continue;
+    }
+    // Skip preamble before the first release heading.
+    if (!entry) continue;
+
+    const heading = SECTION_HEADING.exec(trimmed);
+    if (heading) {
+      section = { title: heading[1], items: [] };
+      entry.sections.push(section);
+      continue;
+    }
+
+    const bullet = BULLET.exec(trimmed);
+    if (bullet) {
+      // Bullets before any `###` fall into an implicit group.
+      if (!section) {
+        section = { title: "Changes", items: [] };
+        entry.sections.push(section);
+      }
+      section.items.push(bullet[1]);
+    }
+  }
+
+  return entries;
+}
+
+/** Release notes, newest-first, parsed from the project CHANGELOG. */
+export const CHANGELOG: ChangelogEntry[] = parseChangelog(changelogRaw);
+
+/** Latest released version — single source of truth for the badge. */
+export const APP_VERSION: string = CHANGELOG[0]?.version ?? "0.0.0";

--- a/page/src/ui/layout/ChangelogDialog.tsx
+++ b/page/src/ui/layout/ChangelogDialog.tsx
@@ -1,0 +1,72 @@
+import type React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { CHANGELOG } from "@/lib/changelog";
+
+interface ChangelogDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Release notes, opened from the version badge in the {@link TopBar}.
+ *
+ * Reads {@link CHANGELOG} (newest-first) and renders each release as a
+ * dated heading followed by grouped bullet sections.
+ */
+export const ChangelogDialog: React.FC<ChangelogDialogProps> = ({
+  open,
+  onOpenChange,
+}) => {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[480px] max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>What's new</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-5 py-2">
+          {CHANGELOG.map((entry) => (
+            <div key={entry.version}>
+              <div className="flex items-baseline gap-2 mb-2">
+                <h3 className="text-sm font-semibold tracking-tight">
+                  v{entry.version}
+                </h3>
+                {entry.date && (
+                  <span className="text-[10px] text-muted-foreground">
+                    {entry.date}
+                  </span>
+                )}
+              </div>
+              <div className="space-y-3">
+                {entry.sections.map((section) => (
+                  <div key={section.title}>
+                    <h4 className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wide mb-1">
+                      {section.title}
+                    </h4>
+                    <ul className="space-y-0.5">
+                      {section.items.map((item) => (
+                        <li
+                          key={item}
+                          className="text-xs text-foreground flex gap-1.5"
+                        >
+                          <span className="text-muted-foreground select-none">
+                            ·
+                          </span>
+                          <span>{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/page/src/ui/layout/TopBar.tsx
+++ b/page/src/ui/layout/TopBar.tsx
@@ -3,6 +3,8 @@ import { BrushCleaning, Focus, Maximize, Redo2, Undo2 } from "lucide-react";
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import { APP_VERSION } from "@/lib/changelog";
+import { ChangelogDialog } from "./ChangelogDialog";
 import { ExportDialog } from "./ExportDialog";
 import { ScreenshotDialog } from "./ScreenshotDialog";
 import { SettingsDialog } from "./SettingsDialog";
@@ -26,6 +28,7 @@ export const TopBar: React.FC<TopBarProps> = ({
 }) => {
   const [canUndo, setCanUndo] = React.useState(false);
   const [canRedo, setCanRedo] = React.useState(false);
+  const [changelogOpen, setChangelogOpen] = React.useState(false);
 
   React.useEffect(() => {
     if (!app) return;
@@ -79,71 +82,82 @@ export const TopBar: React.FC<TopBarProps> = ({
   };
 
   return (
-    <div className="h-8 border-b bg-background flex items-center px-2 gap-2 shrink-0 justify-between">
-      <div className="flex items-center gap-2 min-w-0">
-        <div className="font-semibold tracking-wide text-xs">MolVis</div>
-        <div className="h-4 px-1.5 rounded border bg-muted/30 text-[9px] uppercase tracking-wide text-muted-foreground inline-flex items-center">
-          {currentMode}
+    <>
+      <div className="h-8 border-b bg-background flex items-center px-2 gap-2 shrink-0 justify-between">
+        <div className="flex items-center gap-2 min-w-0">
+          <div className="font-semibold tracking-wide text-xs">MolVis</div>
+          <button
+            type="button"
+            onClick={() => setChangelogOpen(true)}
+            title="What's new"
+            className="font-mono text-[9px] leading-none text-muted-foreground/50 hover:text-muted-foreground transition-colors cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded px-0.5"
+          >
+            v{APP_VERSION}
+          </button>
+          <div className="h-4 px-1.5 rounded border bg-muted/30 text-[9px] uppercase tracking-wide text-muted-foreground inline-flex items-center">
+            {currentMode}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-0.5">
+          <ScreenshotDialog app={app} />
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={handleReset}
+            title="Reset Scene"
+          >
+            <BrushCleaning className="h-3.5 w-3.5" />
+          </Button>
+          <ExportDialog app={app} />
+          <Separator orientation="vertical" className="h-4 mx-0.5" />
+
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={handleUndo}
+            title="Undo"
+            disabled={!canUndo}
+          >
+            <Undo2 className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={handleRedo}
+            title="Redo"
+            disabled={!canRedo}
+          >
+            <Redo2 className="h-3.5 w-3.5" />
+          </Button>
+
+          <Separator orientation="vertical" className="h-4 mx-0.5" />
+
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={handleResetCamera}
+            title="Reset Camera"
+          >
+            <Focus className="h-3.5 w-3.5" />
+          </Button>
+
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onToggleFullscreen}
+            title="Fullscreen (hide UI)"
+          >
+            <Maximize className="h-3.5 w-3.5" />
+          </Button>
+
+          <Separator orientation="vertical" className="h-4 mx-0.5" />
+
+          <ThemeToggle />
+          <SettingsDialog app={app} />
         </div>
       </div>
-
-      <div className="flex items-center gap-0.5">
-        <ScreenshotDialog app={app} />
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          onClick={handleReset}
-          title="Reset Scene"
-        >
-          <BrushCleaning className="h-3.5 w-3.5" />
-        </Button>
-        <ExportDialog app={app} />
-        <Separator orientation="vertical" className="h-4 mx-0.5" />
-
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          onClick={handleUndo}
-          title="Undo"
-          disabled={!canUndo}
-        >
-          <Undo2 className="h-3.5 w-3.5" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          onClick={handleRedo}
-          title="Redo"
-          disabled={!canRedo}
-        >
-          <Redo2 className="h-3.5 w-3.5" />
-        </Button>
-
-        <Separator orientation="vertical" className="h-4 mx-0.5" />
-
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          onClick={handleResetCamera}
-          title="Reset Camera"
-        >
-          <Focus className="h-3.5 w-3.5" />
-        </Button>
-
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          onClick={onToggleFullscreen}
-          title="Fullscreen (hide UI)"
-        >
-          <Maximize className="h-3.5 w-3.5" />
-        </Button>
-
-        <Separator orientation="vertical" className="h-4 mx-0.5" />
-
-        <ThemeToggle />
-        <SettingsDialog app={app} />
-      </div>
-    </div>
+      <ChangelogDialog open={changelogOpen} onOpenChange={setChangelogOpen} />
+    </>
   );
 };

--- a/vsc-ext/rslib.webview.config.mts
+++ b/vsc-ext/rslib.webview.config.mts
@@ -62,6 +62,16 @@ export default defineConfig({
         ...(config.node || {}),
         __dirname: "mock",
       };
+      // Inline the raw text of `?raw` imports (e.g. CHANGELOG.md) as a string.
+      // Mirrors the same rule in page/rsbuild.config.ts — the page source this
+      // webview bundles depends on it.
+      config.module = {
+        ...(config.module || {}),
+        rules: [
+          ...(config.module?.rules || []),
+          { resourceQuery: /raw/, type: "asset/source" },
+        ],
+      };
       config.resolve = {
         ...(config.resolve || {}),
         fallback: {


### PR DESCRIPTION
## Summary
Adds a faint version badge to the top-left of the page top bar. Clicking it opens a "What's new" dialog with the release notes.

Release notes are **read from the project `CHANGELOG.md` at build time** via an `?raw` import, so the markdown is the single source of truth for both the badge version (`APP_VERSION`) and the dialog contents. Updating release notes = editing `CHANGELOG.md`; no code change.

## Changes
- **`CHANGELOG.md`** *(new, repo root)* — canonical Keep-a-Changelog source of truth.
- **`page/src/lib/changelog.ts`** — imports `CHANGELOG.md?raw` and parses it into structured entries; exports `CHANGELOG` + `APP_VERSION`.
- **`page/src/ui/layout/ChangelogDialog.tsx`** *(new)* — Radix dialog rendering the entries, styled to match `KeyboardShortcutsDialog`.
- **`page/src/ui/layout/TopBar.tsx`** — faint `v{APP_VERSION}` button in the top-left that opens the dialog.
- **`page/rsbuild.config.ts`** + **`vsc-ext/rslib.webview.config.mts`** — `asset/source` rule for `?raw` imports (both bundlers, since the vsc-ext webview bundles the page source).
- **`page/src/css.d.ts`** — ambient `*?raw` module declaration.

## Notes
- The `?raw` text is inlined into the JS bundle at build time — no runtime fetch; the markdown travels inside `dist` to the Python/VSCode hosts.
- Repo is version-locked; badge shows `0.0.7`, matching `package.json`. No version bump needed.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run build:all` — page + core + vsc-ext all build (verifies `?raw` under both rsbuild and rslib)
- [x] `npm run lint` (biome) — clean
- [x] Core test suite — passed (pre-commit hook)
- [ ] Manual: `npm run dev:page`, confirm faint `v0.0.7` top-left opens the changelog dialog
- [ ] Manual: confirm the badge/dialog render correctly inside the VSCode webview