### PR TITLE
ci(release-python): drop npm cache + add workflow_dispatch (unblock v0.0.9 PyPI)

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -3,6 +3,8 @@ name: "Release: Python (PyPI)"
 on:
   push:
     tags: ["v*"]
+  # Manual re-trigger to republish after a workflow fix, without re-tagging.
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -15,10 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # No `cache: npm` — the repo intentionally does not commit a lockfile
+      # (see ci.yml). setup-node's npm cache requires one and would fail.
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: "npm"
 
       - name: Install JS dependencies
         run: npm install


### PR DESCRIPTION
The `Release: Python (PyPI)` run for tag v0.0.9 failed at `setup-node@v4` — `cache: npm` needs a committed lockfile, which the repo intentionally omits (same issue ci.yml fixed in 6052acc). core + vsc-ext already published for v0.0.9; only PyPI is pending.

- Drop `cache: npm` from setup-node
- Add `workflow_dispatch` so the Python release can be re-run against master without re-tagging

After merge: dispatch `release-python.yml` on master to publish molcrafts-molvis 0.0.9.