### PR TITLE
Release 0.0.10 — vsc-ext three-surface redesign + page chrome flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ page reads it at build time (see `page/src/lib/changelog.ts`). Keep the
 format below: `## [version] - date`, then `### Section` groups, then
 `- bullet` items.
 
+## [0.0.10] - 2026-07-05
+
+### VSCode
+- Three distinct viewer surfaces, cleanly separated:
+  - **Quick View** — the lightweight core canvas (editor title-bar
+    `molvis.quickView` + the `molvis.editor` custom editor) for a fast peek at an
+    opened molecular file.
+  - **MolVis** — the full React page, now hosted in a new **activity-bar view**
+    (`WebviewViewProvider`, registered with `retainContextWhenHidden` so the
+    WebGL scene survives the view being collapsed). New monochrome activity-bar
+    icon.
+  - **MolVis (wide)** — the full page in a wide editor tab (`molvis.openEditor`).
+- `PanelRegistry` widened to broadcast reload/settings to both webview panels and
+  the activity-bar webview view.
+
+### Page
+- Host-aware chrome flags: a `MountOpts.surface` preset (`"full"` | `"canvas"`)
+  plus per-panel `chrome` overrides, plumbed from the VSCode host through
+  `window.__MOLVIS_VSCODE_INIT__.mount`. The legacy `minimal` flag becomes a
+  backward-compat alias for `surface: "canvas"`.
+
 ## [0.0.9] - 2026-07-04
 
 ### Core

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@molcrafts/molvis-core",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "molvis",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "interactive molecule visulization package",
   "author": "Roy Kid",
   "license": "BSD-3-Clause",

--- a/page/package.json
+++ b/page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "page",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "main": "index.js",
   "type": "module",
   "keywords": [],

--- a/page/src/App.tsx
+++ b/page/src/App.tsx
@@ -18,7 +18,7 @@ import { useBackendStateSync } from "@/hooks/useBackendStateSync";
 import { useHostFileBridge } from "@/hooks/useHostFileBridge";
 import { useMolvisUiState } from "@/hooks/useMolvisUiState";
 import { useStatusMessage } from "@/hooks/useStatusMessage";
-import { useMountOpts } from "@/lib/mount-opts";
+import { resolveChrome, useMountOpts } from "@/lib/mount-opts";
 import MolvisWrapper from "./MolvisWrapper";
 import { KeyboardShortcutsDialog } from "./ui/layout/KeyboardShortcutsDialog";
 import { LeftSidebar } from "./ui/layout/LeftSidebar";
@@ -35,7 +35,13 @@ import { CameraTrajectoryOverlay } from "./ui/modes/view/CameraTrajectoryOverlay
  */
 const App: React.FC = () => {
   const opts = useMountOpts();
-  const minimalMode = Boolean(opts.minimal);
+  const chrome = resolveChrome(opts);
+  const canvasOnly =
+    !chrome.topBar &&
+    !chrome.leftSidebar &&
+    !chrome.rightSidebar &&
+    !chrome.statusBar &&
+    !chrome.timeline;
 
   const [app, setApp] = useState<Molvis | null>(null);
   const { currentMode, setCurrentMode, trajectoryLength } =
@@ -79,7 +85,7 @@ const App: React.FC = () => {
     setCurrentMode(mode);
   };
 
-  if (minimalMode) {
+  if (canvasOnly) {
     return (
       <ErrorBoundary>
         <BackendConnectionProvider
@@ -127,7 +133,7 @@ const App: React.FC = () => {
               className="h-full w-full flex flex-col bg-background text-foreground overflow-hidden"
               onContextMenu={(e) => e.preventDefault()}
             >
-              {!uiHidden && (
+              {!uiHidden && chrome.topBar && (
                 <TopBar
                   app={app}
                   currentMode={currentMode}
@@ -141,7 +147,7 @@ const App: React.FC = () => {
                 defaultLayout={{ left: 0, canvas: 87, right: 13 }}
                 resizeTargetMinimumSize={{ fine: 20, coarse: 36 }}
               >
-                {!uiHidden && (
+                {!uiHidden && chrome.leftSidebar && (
                   <ResizablePanel
                     key="left"
                     id="left"
@@ -156,7 +162,9 @@ const App: React.FC = () => {
                   </ResizablePanel>
                 )}
 
-                {!uiHidden && <ResizableHandle key="handle-left" withHandle />}
+                {!uiHidden && chrome.leftSidebar && (
+                  <ResizableHandle key="handle-left" withHandle />
+                )}
 
                 <ResizablePanel
                   key="canvas"
@@ -181,19 +189,24 @@ const App: React.FC = () => {
                     )}
                   </div>
 
-                  {app && trajectoryLength > 1 && !uiHidden && (
-                    <div className="h-9 border-t bg-muted/20 shrink-0 z-10">
-                      <TimelineControl
-                        app={app}
-                        totalFrames={trajectoryLength}
-                      />
-                    </div>
-                  )}
+                  {app &&
+                    trajectoryLength > 1 &&
+                    !uiHidden &&
+                    chrome.timeline && (
+                      <div className="h-9 border-t bg-muted/20 shrink-0 z-10">
+                        <TimelineControl
+                          app={app}
+                          totalFrames={trajectoryLength}
+                        />
+                      </div>
+                    )}
                 </ResizablePanel>
 
-                {!uiHidden && <ResizableHandle key="handle-right" withHandle />}
+                {!uiHidden && chrome.rightSidebar && (
+                  <ResizableHandle key="handle-right" withHandle />
+                )}
 
-                {!uiHidden && (
+                {!uiHidden && chrome.rightSidebar && (
                   <ResizablePanel
                     key="right"
                     id="right"
@@ -213,7 +226,7 @@ const App: React.FC = () => {
                 )}
               </ResizablePanelGroup>
 
-              {!uiHidden && (
+              {!uiHidden && chrome.statusBar && (
                 <div
                   className={`h-4 border-t bg-muted/60 flex items-center px-2 text-[9px] shrink-0 ${statusType === "error" ? "text-red-500 font-bold bg-red-100/10" : "text-muted-foreground"}`}
                 >

--- a/page/src/index.tsx
+++ b/page/src/index.tsx
@@ -4,7 +4,7 @@ import {
   type MountHostOpts,
   mountMolvisApp,
 } from "@/lib/mount";
-import { readMountOptsFromUrl } from "@/lib/mount-opts";
+import { readMountOptsFromHost, readMountOptsFromUrl } from "@/lib/mount-opts";
 import "@/styles/tailwind.css";
 import { bootstrapTheme } from "./hooks/useTheme";
 
@@ -34,6 +34,7 @@ if (typeof document !== "undefined") {
     bootstrapTheme();
     mountMolvisApp(rootEl, {
       ...readMountOptsFromUrl(),
+      ...readMountOptsFromHost(),
       useShadowDOM: false,
     });
   }

--- a/page/src/lib/mount-opts.ts
+++ b/page/src/lib/mount-opts.ts
@@ -1,6 +1,33 @@
 import { createContext, useContext } from "react";
 
 /**
+ * Named surface presets for the page chrome layout.
+ *
+ * - `"full"` — all chrome visible (default).
+ * - `"canvas"` — no chrome; 3D canvas only (identical to the legacy
+ *   `minimal: true` flag).
+ */
+export type MolvisSurface = "full" | "canvas";
+
+/**
+ * Per-panel visibility flags applied on top of the {@link MolvisSurface}
+ * preset. Every flag defaults to the surface's default; set only the
+ * panels you want to override.
+ */
+export interface MolvisChromeFlags {
+  /** Top bar (mode selector, fullscreen toggle, settings). */
+  topBar?: boolean;
+  /** Left sidebar (analysis, RDF, pipeline). */
+  leftSidebar?: boolean;
+  /** Right sidebar (mode-specific panels). */
+  rightSidebar?: boolean;
+  /** Bottom status bar. */
+  statusBar?: boolean;
+  /** Timeline control (only shown when trajectory length > 1). */
+  timeline?: boolean;
+}
+
+/**
  * Configuration passed to {@link mountMolvisApp} when bootstrapping the
  * page. Standalone mode reads these from URL params; the notebook host
  * passes them inline via `window.MolvisApp.mount(el, opts)`.
@@ -12,7 +39,21 @@ export interface MountOpts {
   token?: string;
   /** Session label sent with hello and used in event routing. */
   session?: string;
-  /** When `true`, hide all chrome and render only the canvas. */
+  /**
+   * Named surface preset. `"canvas"` hides all chrome; `"full"` (default)
+   * shows everything. Override individual panels with {@link chrome}.
+   */
+  surface?: MolvisSurface;
+  /**
+   * Per-panel visibility overrides. Applied on top of the surface preset;
+   * only the keys you set are overridden.
+   */
+  chrome?: MolvisChromeFlags;
+  /**
+   * When `true`, hide all chrome and render only the canvas.
+   * @deprecated Use `surface: "canvas"` instead; this alias is honored for
+   * backward compatibility.
+   */
   minimal?: boolean;
   /**
    * Opt-in demo seed. `true` seeds a Dopamine molecule on start; `false`
@@ -30,6 +71,62 @@ export const MountOptsProvider = MountOptsContext.Provider;
 
 export function useMountOpts(): MountOpts {
   return useContext(MountOptsContext);
+}
+
+/**
+ * Resolve the effective chrome flags from a {@link MountOpts} value.
+ *
+ * Precedence (highest wins): `chrome` overrides → `surface` preset →
+ * legacy `minimal` alias. When nothing is specified the default is
+ * `surface: "full"` (all flags `true`).
+ */
+export function resolveChrome(opts: MountOpts): Required<MolvisChromeFlags> {
+  const surface = opts.surface ?? (opts.minimal ? "canvas" : "full");
+
+  const defaults: Required<MolvisChromeFlags> =
+    surface === "canvas"
+      ? {
+          topBar: false,
+          leftSidebar: false,
+          rightSidebar: false,
+          statusBar: false,
+          timeline: false,
+        }
+      : {
+          topBar: true,
+          leftSidebar: true,
+          rightSidebar: true,
+          statusBar: true,
+          timeline: true,
+        };
+
+  return {
+    topBar: opts.chrome?.topBar ?? defaults.topBar,
+    leftSidebar: opts.chrome?.leftSidebar ?? defaults.leftSidebar,
+    rightSidebar: opts.chrome?.rightSidebar ?? defaults.rightSidebar,
+    statusBar: opts.chrome?.statusBar ?? defaults.statusBar,
+    timeline: opts.chrome?.timeline ?? defaults.timeline,
+  };
+}
+
+/**
+ * Read mount options injected by the VSCode extension host via
+ * `window.__MOLVIS_VSCODE_INIT__`. Returns an empty object when the
+ * global is absent (e.g. standalone or notebook hosts) so the result
+ * is always safe to spread.
+ */
+export function readMountOptsFromHost(): Partial<MountOpts> {
+  if (typeof window === "undefined") return {};
+
+  const init = (
+    window as Window &
+      typeof globalThis & {
+        __MOLVIS_VSCODE_INIT__?: { mount?: Partial<MountOpts> };
+      }
+  ).__MOLVIS_VSCODE_INIT__;
+
+  if (!init?.mount) return {};
+  return init.mount;
 }
 
 /** Build {@link MountOpts} from the current `window.location.search`. */

--- a/page/tests/mount-opts.test.ts
+++ b/page/tests/mount-opts.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "@rstest/core";
+import { readMountOptsFromHost, resolveChrome } from "../src/lib/mount-opts";
+
+// Pure unit tests for the surface/flag model. resolveChrome is a
+// pure function — no DOM or React needed. readMountOptsFromHost
+// is tested with a minimal window mock.
+
+describe("resolveChrome", () => {
+  it("surface full → all flags true", () => {
+    const result = resolveChrome({ surface: "full" });
+    expect(result.topBar).toBe(true);
+    expect(result.leftSidebar).toBe(true);
+    expect(result.rightSidebar).toBe(true);
+    expect(result.statusBar).toBe(true);
+    expect(result.timeline).toBe(true);
+  });
+
+  it("surface canvas → all flags false", () => {
+    const result = resolveChrome({ surface: "canvas" });
+    expect(result.topBar).toBe(false);
+    expect(result.leftSidebar).toBe(false);
+    expect(result.rightSidebar).toBe(false);
+    expect(result.statusBar).toBe(false);
+    expect(result.timeline).toBe(false);
+  });
+
+  it("minimal:true → same as canvas (backward-compat alias)", () => {
+    const fromMinimal = resolveChrome({ minimal: true });
+    const fromCanvas = resolveChrome({ surface: "canvas" });
+    expect(fromMinimal).toEqual(fromCanvas);
+  });
+
+  it("default (no surface, no minimal) → all true", () => {
+    const result = resolveChrome({});
+    expect(result.topBar).toBe(true);
+    expect(result.leftSidebar).toBe(true);
+    expect(result.rightSidebar).toBe(true);
+    expect(result.statusBar).toBe(true);
+    expect(result.timeline).toBe(true);
+  });
+
+  it("chrome override wins over surface preset", () => {
+    const result = resolveChrome({
+      surface: "full",
+      chrome: { leftSidebar: false, statusBar: false },
+    });
+    expect(result.topBar).toBe(true);
+    expect(result.leftSidebar).toBe(false); // overridden
+    expect(result.rightSidebar).toBe(true);
+    expect(result.statusBar).toBe(false); // overridden
+    expect(result.timeline).toBe(true);
+  });
+
+  it("chrome partial override on canvas surface", () => {
+    const result = resolveChrome({
+      surface: "canvas",
+      chrome: { topBar: true },
+    });
+    expect(result.topBar).toBe(true); // turned on via override
+    expect(result.leftSidebar).toBe(false);
+    expect(result.rightSidebar).toBe(false);
+    expect(result.statusBar).toBe(false);
+    expect(result.timeline).toBe(false);
+  });
+
+  it("surface takes precedence over minimal when both set", () => {
+    // surface is explicit; minimal is only a fallback
+    const result = resolveChrome({ surface: "full", minimal: true });
+    expect(result.topBar).toBe(true);
+    expect(result.leftSidebar).toBe(true);
+  });
+});
+
+describe("readMountOptsFromHost", () => {
+  it("returns empty object when __MOLVIS_VSCODE_INIT__ is absent", () => {
+    // In a pure Node test, window is undefined — the function guards this.
+    const result = readMountOptsFromHost();
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object when mount key is missing", () => {
+    // Simulate an init object without mount — the function reads
+    // __MOLVIS_VSCODE_INIT__.mount specifically.
+    const saved = (globalThis as Record<string, unknown>)
+      .__MOLVIS_VSCODE_INIT__;
+    (globalThis as Record<string, unknown>).__MOLVIS_VSCODE_INIT__ = {
+      config: {},
+    };
+    try {
+      const result = readMountOptsFromHost();
+      expect(result).toEqual({});
+    } finally {
+      if (saved !== undefined) {
+        (globalThis as Record<string, unknown>).__MOLVIS_VSCODE_INIT__ = saved;
+      } else {
+        delete (globalThis as Record<string, unknown>).__MOLVIS_VSCODE_INIT__;
+      }
+    }
+  });
+
+  it("returns mount.surface from the host payload", () => {
+    const saved = (globalThis as Record<string, unknown>)
+      .__MOLVIS_VSCODE_INIT__;
+    (globalThis as Record<string, unknown>).__MOLVIS_VSCODE_INIT__ = {
+      mount: { surface: "full" },
+    };
+    try {
+      const result = readMountOptsFromHost();
+      expect(result).toEqual({ surface: "full" });
+    } finally {
+      if (saved !== undefined) {
+        (globalThis as Record<string, unknown>).__MOLVIS_VSCODE_INIT__ = saved;
+      } else {
+        delete (globalThis as Record<string, unknown>).__MOLVIS_VSCODE_INIT__;
+      }
+    }
+  });
+});

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "molcrafts-molvis"
-version = "0.0.9"
+version = "0.0.10"
 description = "Molecular visualization driven by a local WebSocket-hosted page"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/vsc-ext/image/molvis-activitybar.svg
+++ b/vsc-ext/image/molvis-activitybar.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Hexagon ring (benzene-like) -->
+  <polygon points="12,3 20,7 20,15 12,19 4,15 4,7" />
+  <!-- Inner circle (delocalized electrons) -->
+  <circle cx="12" cy="11" r="3" />
+</svg>

--- a/vsc-ext/package.json
+++ b/vsc-ext/package.json
@@ -12,7 +12,7 @@
   },
   "license": "BSD-3-Clause",
   "icon": "image/molvis-icon.png",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "engines": {
     "vscode": "^1.120.0"
   },
@@ -32,10 +32,28 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "molvis",
+          "title": "MolVis",
+          "icon": "image/molvis-activitybar.svg"
+        }
+      ]
+    },
+    "views": {
+      "molvis": [
+        {
+          "type": "webview",
+          "id": "molvis.pageView",
+          "name": "Viewer"
+        }
+      ]
+    },
     "commands": [
       {
         "command": "molvis.quickView",
-        "title": "MolVis: Quick Preview",
+        "title": "MolVis: Quick View",
         "icon": "$(eye)"
       },
       {
@@ -64,7 +82,7 @@
     "customEditors": [
       {
         "viewType": "molvis.editor",
-        "displayName": "MolVis Quick Preview",
+        "displayName": "MolVis Quick View",
         "selector": [
           {
             "filenamePattern": "*.pdb"

--- a/vsc-ext/src/extension/activate.ts
+++ b/vsc-ext/src/extension/activate.ts
@@ -9,6 +9,7 @@ import { MolvisBinaryEditorProvider } from "./panels/binaryEditorProvider";
 import { MolvisEditorProvider } from "./panels/editorProvider";
 import { createHotReloadWatcher } from "./panels/hotReload";
 import { sendToWebview } from "./panels/messaging";
+import { MolvisPageViewProvider } from "./panels/pageViewProvider";
 import { InMemoryPanelRegistry } from "./panels/panelRegistry";
 import { openQuickViewPanel } from "./panels/previewPanel";
 import { openEditorPanel } from "./panels/viewerPanel";
@@ -33,6 +34,16 @@ export function activate(context: vscode.ExtensionContext): void {
       panelRegistry,
       logger,
       fileLoader,
+    ),
+    vscode.window.registerWebviewViewProvider(
+      MolvisPageViewProvider.viewType,
+      new MolvisPageViewProvider(
+        context.extensionUri,
+        panelRegistry,
+        logger,
+        fileLoader,
+      ),
+      { webviewOptions: { retainContextWhenHidden: true } },
     ),
     vscode.commands.registerCommand(
       "molvis.quickView",

--- a/vsc-ext/src/extension/configuration.ts
+++ b/vsc-ext/src/extension/configuration.ts
@@ -4,6 +4,8 @@ import type { HostToWebviewMessage } from "./types";
 export interface MolvisWebviewOptions {
   config?: Record<string, unknown>;
   settings?: Record<string, unknown>;
+  /** Mount options forwarded to the page bundle's `readMountOptsFromHost()`. */
+  mount?: { surface?: string };
 }
 
 function asObject(value: unknown): Record<string, unknown> | undefined {
@@ -13,21 +15,21 @@ function asObject(value: unknown): Record<string, unknown> | undefined {
   return value as Record<string, unknown>;
 }
 
-export function getMolvisWebviewOptions(): MolvisWebviewOptions {
+export function getMolvisWebviewOptions(
+  surface?: string,
+): MolvisWebviewOptions {
   const cfg = vscode.workspace.getConfiguration("molvis");
   return {
     config: asObject(cfg.get("config")),
     settings: asObject(cfg.get("settings")),
+    ...(surface ? { mount: { surface } } : {}),
   };
 }
 
-export function createInitMessage(
-  mode: "standalone" | "editor" | "app",
-): HostToWebviewMessage {
+export function createInitMessage(): HostToWebviewMessage {
   const options = getMolvisWebviewOptions();
   return {
     type: "init",
-    mode,
     config: options.config,
     settings: options.settings,
   };

--- a/vsc-ext/src/extension/panels/binaryEditorProvider.ts
+++ b/vsc-ext/src/extension/panels/binaryEditorProvider.ts
@@ -85,7 +85,7 @@ export class MolvisBinaryEditorProvider
       withErrorHandler(async (message) => {
         switch (message.type) {
           case "ready":
-            sendToWebview(webviewPanel.webview, createInitMessage("editor"));
+            sendToWebview(webviewPanel.webview, createInitMessage());
             await sendLoadedFile(
               webviewPanel.webview,
               document.uri,

--- a/vsc-ext/src/extension/panels/editorProvider.ts
+++ b/vsc-ext/src/extension/panels/editorProvider.ts
@@ -71,7 +71,7 @@ export class MolvisEditorProvider implements vscode.CustomTextEditorProvider {
       withErrorHandler(async (message) => {
         switch (message.type) {
           case "ready":
-            sendToWebview(webviewPanel.webview, createInitMessage("editor"));
+            sendToWebview(webviewPanel.webview, createInitMessage());
             await loadTextDocumentToWebview(webviewPanel.webview, document);
             break;
           case "saveFile":

--- a/vsc-ext/src/extension/panels/pageViewProvider.ts
+++ b/vsc-ext/src/extension/panels/pageViewProvider.ts
@@ -1,0 +1,88 @@
+import * as vscode from "vscode";
+import { createInitMessage, getMolvisWebviewOptions } from "../configuration";
+import type { MolecularFileLoader } from "../loading/molecularFileLoader";
+import type { Logger, PanelRegistry } from "../types";
+import { withErrorHandler } from "./errorBoundary";
+import { getViewerHtml } from "./html";
+import { handleDropUri, onWebviewMessage, sendToWebview } from "./messaging";
+
+/**
+ * Activity-bar webview view provider for the full MolVis page.
+ *
+ * Hosts the React page bundle in the activity-bar sidebar with
+ * `retainContextWhenHidden: true` so the scene survives collapse/reopen.
+ * Registers itself in the shared {@link PanelRegistry} so
+ * `molvis.reload` and settings-change broadcasts reach it.
+ */
+export class MolvisPageViewProvider implements vscode.WebviewViewProvider {
+  public static readonly viewType = "molvis.pageView";
+
+  private _view?: vscode.WebviewView;
+
+  constructor(
+    private readonly extensionUri: vscode.Uri,
+    private readonly panelRegistry: PanelRegistry,
+    private readonly logger: Logger,
+    private readonly fileLoader: MolecularFileLoader,
+  ) {}
+
+  resolveWebviewView(
+    webviewView: vscode.WebviewView,
+    _context: vscode.WebviewViewResolveContext,
+    _token: vscode.CancellationToken,
+  ): void {
+    this._view = webviewView;
+
+    webviewView.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, "out")],
+    };
+
+    webviewView.webview.html = getViewerHtml(
+      webviewView.webview,
+      this.extensionUri,
+      getMolvisWebviewOptions("full"),
+    );
+
+    const messageDisposable = onWebviewMessage(
+      webviewView.webview,
+      withErrorHandler(async (message) => {
+        switch (message.type) {
+          case "ready":
+            sendToWebview(webviewView.webview, createInitMessage());
+            break;
+          case "dropUri":
+            await handleDropUri(
+              message.uri,
+              webviewView.webview,
+              this.fileLoader,
+              this.logger,
+            );
+            break;
+          case "error":
+            this.logger.error(`MolVis page view: ${message.message}`);
+            break;
+          default:
+            break;
+        }
+      }, this.logger),
+    );
+
+    // Register in the shared panel registry so molvis.reload and
+    // settings-change broadcasts reach this view.
+    this.panelRegistry.register(webviewView, {
+      getHtml: () =>
+        getViewerHtml(
+          webviewView.webview,
+          this.extensionUri,
+          getMolvisWebviewOptions("full"),
+        ),
+      viewType: MolvisPageViewProvider.viewType,
+    });
+
+    webviewView.onDidDispose(() => {
+      this.panelRegistry.unregister(webviewView);
+      messageDisposable.dispose();
+    });
+  }
+}

--- a/vsc-ext/src/extension/panels/panelRegistry.ts
+++ b/vsc-ext/src/extension/panels/panelRegistry.ts
@@ -1,27 +1,35 @@
-import type * as vscode from "vscode";
-import type { PanelRegistry, WebviewPanelMeta } from "../types";
+import type { PanelHandle, PanelRegistry, WebviewPanelMeta } from "../types";
 
 /**
  * In-memory registry for active webview panels and their reload metadata.
+ * Accepts both `WebviewPanel` and `WebviewView` via the {@link PanelHandle}
+ * structural type so a single broadcast path serves all surfaces.
  */
 export class InMemoryPanelRegistry implements PanelRegistry {
-  private readonly panels = new Map<vscode.WebviewPanel, WebviewPanelMeta>();
+  private readonly panels = new Map<PanelHandle, WebviewPanelMeta>();
 
-  public register(panel: vscode.WebviewPanel, meta: WebviewPanelMeta): void {
+  public register(panel: PanelHandle, meta: WebviewPanelMeta): void {
     this.panels.set(panel, meta);
   }
 
-  public unregister(panel: vscode.WebviewPanel): void {
+  public unregister(panel: PanelHandle): void {
     this.panels.delete(panel);
   }
 
   public getRegisteredViewTypes(): readonly string[] {
-    return [...this.panels.keys()].map((panel) => panel.viewType);
+    const types: string[] = [];
+    for (const [panel, meta] of this.panels) {
+      // Prefer explicit viewType in meta (used by WebviewView providers);
+      // fall back to the panel's own viewType (WebviewPanel).
+      const vt = meta.viewType ?? (panel as { viewType?: string }).viewType;
+      if (vt) types.push(vt);
+    }
+    return types;
   }
 
   public async forEachVisible(
     callback: (
-      panel: vscode.WebviewPanel,
+      panel: PanelHandle,
       meta: WebviewPanelMeta,
     ) => Promise<void> | void,
   ): Promise<void> {
@@ -34,7 +42,7 @@ export class InMemoryPanelRegistry implements PanelRegistry {
 
   public async forEach(
     callback: (
-      panel: vscode.WebviewPanel,
+      panel: PanelHandle,
       meta: WebviewPanelMeta,
     ) => Promise<void> | void,
   ): Promise<void> {

--- a/vsc-ext/src/extension/panels/previewPanel.ts
+++ b/vsc-ext/src/extension/panels/previewPanel.ts
@@ -57,7 +57,7 @@ export async function openQuickViewPanel(
     withErrorHandler(async (message) => {
       switch (message.type) {
         case "ready":
-          sendToWebview(panel.webview, createInitMessage("standalone"));
+          sendToWebview(panel.webview, createInitMessage());
           if (targetUri) {
             await sendLoadedFile(panel.webview, targetUri, fileLoader, logger);
           }

--- a/vsc-ext/src/extension/panels/viewerPanel.ts
+++ b/vsc-ext/src/extension/panels/viewerPanel.ts
@@ -34,7 +34,7 @@ export function openEditorPanel(
   panel.webview.html = getViewerHtml(
     panel.webview,
     context.extensionUri,
-    getMolvisWebviewOptions(),
+    getMolvisWebviewOptions("full"),
   );
 
   const messageDisposable = onWebviewMessage(
@@ -42,7 +42,7 @@ export function openEditorPanel(
     withErrorHandler(async (message) => {
       switch (message.type) {
         case "ready":
-          sendToWebview(panel.webview, createInitMessage("app"));
+          sendToWebview(panel.webview, createInitMessage());
           if (uri) {
             await sendLoadedFile(panel.webview, uri, fileLoader, logger);
           }
@@ -64,7 +64,7 @@ export function openEditorPanel(
       getViewerHtml(
         panel.webview,
         context.extensionUri,
-        getMolvisWebviewOptions(),
+        getMolvisWebviewOptions("full"),
       ),
   });
 

--- a/vsc-ext/src/extension/types.ts
+++ b/vsc-ext/src/extension/types.ts
@@ -73,7 +73,6 @@ export type MolecularLoadMode = "replace" | "append" | "auto";
 export type HostToWebviewMessage =
   | {
       type: "init";
-      mode: "standalone" | "editor" | "app";
       config?: unknown;
       settings?: unknown;
     }
@@ -101,24 +100,36 @@ export type WebviewToHostMessage =
 
 // --- Panel (was types/panel.ts) ---
 
+/**
+ * Minimal structural handle for a webview host. Both `vscode.WebviewPanel`
+ * and `vscode.WebviewView` satisfy this; the registry uses it so a single
+ * broadcast path serves both panel types.
+ */
+export interface PanelHandle {
+  readonly webview: vscode.Webview;
+  readonly visible: boolean;
+}
+
 export interface WebviewPanelMeta {
   getHtml: () => string;
   reload?: () => Promise<void>;
+  /** Explicit view type for hosts that don't carry one natively (e.g. WebviewView). */
+  viewType?: string;
 }
 
 export interface PanelRegistry {
-  register(panel: vscode.WebviewPanel, meta: WebviewPanelMeta): void;
-  unregister(panel: vscode.WebviewPanel): void;
+  register(panel: PanelHandle, meta: WebviewPanelMeta): void;
+  unregister(panel: PanelHandle): void;
   getRegisteredViewTypes(): readonly string[];
   forEachVisible(
     callback: (
-      panel: vscode.WebviewPanel,
+      panel: PanelHandle,
       meta: WebviewPanelMeta,
     ) => Promise<void> | void,
   ): Promise<void>;
   forEach(
     callback: (
-      panel: vscode.WebviewPanel,
+      panel: PanelHandle,
       meta: WebviewPanelMeta,
     ) => Promise<void> | void,
   ): Promise<void>;

--- a/vsc-ext/src/test/integration/extension-host/commands.test.ts
+++ b/vsc-ext/src/test/integration/extension-host/commands.test.ts
@@ -59,6 +59,40 @@ suite("extension host commands", () => {
     await vscode.commands.executeCommand("workbench.action.closeAllEditors");
   });
 
+  test("pageView is declared in package.json contributions", () => {
+    const ext = vscode.extensions.getExtension("molcrafts.molvis");
+    assert.ok(ext, "Expected molcrafts.molvis extension to be installed");
+
+    const pkg = ext.packageJSON;
+    assert.ok(pkg, "Expected package.json to be readable");
+
+    const views = pkg?.contributes?.views as
+      | Record<string, unknown[]>
+      | undefined;
+    assert.ok(views, "Expected contributes.views to be defined");
+    assert.ok(views?.molvis, "Expected views.molvis to be defined");
+
+    const pageView = (views?.molvis as Array<{ id: string }> | undefined)?.find(
+      (v) => v.id === "molvis.pageView",
+    );
+    assert.ok(pageView, "Expected molvis.pageView in views.molvis");
+  });
+
+  test("activity bar container is declared", () => {
+    const ext = vscode.extensions.getExtension("molcrafts.molvis");
+    assert.ok(ext, "Expected molcrafts.molvis extension to be installed");
+
+    const containers = ext.packageJSON?.contributes?.viewsContainers as
+      | { activitybar?: Array<{ id: string }> }
+      | undefined;
+    assert.ok(containers, "Expected contributes.viewsContainers to be defined");
+
+    const molvisContainer = containers?.activitybar?.find(
+      (c) => c.id === "molvis",
+    );
+    assert.ok(molvisContainer, "Expected molvis activity bar container");
+  });
+
   test("quickView accepts URI argument", async () => {
     const filePath = path.join(
       os.tmpdir(),

--- a/vsc-ext/src/test/unit/extension/panelRegistry.test.ts
+++ b/vsc-ext/src/test/unit/extension/panelRegistry.test.ts
@@ -1,27 +1,29 @@
 import * as assert from "assert";
 import { InMemoryPanelRegistry } from "../../../extension/panels/panelRegistry";
+import type { PanelHandle } from "../../../extension/types";
 
-interface MockPanel {
-  visible: boolean;
-  webview: { html: string };
+/** A minimal `PanelHandle` mock that looks like a `WebviewView`. */
+function makePanelHandle(opts: {
+  webview?: Partial<PanelHandle["webview"]>;
+  visible?: boolean;
+  viewType?: string;
+}): PanelHandle {
+  return {
+    webview: (opts.webview ?? { html: "" }) as PanelHandle["webview"],
+    visible: opts.visible ?? true,
+    ...(opts.viewType ? { viewType: opts.viewType } : {}),
+  } as PanelHandle;
 }
 
 suite("panelRegistry", () => {
   test("forEachVisible only visits visible panels", async () => {
     const registry = new InMemoryPanelRegistry();
 
-    const visiblePanel = {
-      visible: true,
-      webview: { html: "" },
-    } as unknown as MockPanel;
+    const visiblePanel = makePanelHandle({ visible: true });
+    const hiddenPanel = makePanelHandle({ visible: false });
 
-    const hiddenPanel = {
-      visible: false,
-      webview: { html: "" },
-    } as unknown as MockPanel;
-
-    registry.register(visiblePanel as never, { getHtml: () => "visible" });
-    registry.register(hiddenPanel as never, { getHtml: () => "hidden" });
+    registry.register(visiblePanel, { getHtml: () => "visible" });
+    registry.register(hiddenPanel, { getHtml: () => "hidden" });
 
     const htmlValues: string[] = [];
     await registry.forEachVisible((_panel, meta) => {
@@ -33,13 +35,10 @@ suite("panelRegistry", () => {
 
   test("unregister removes panel from traversal", async () => {
     const registry = new InMemoryPanelRegistry();
-    const panel = {
-      visible: true,
-      webview: { html: "" },
-    } as unknown as MockPanel;
+    const panel = makePanelHandle({});
 
-    registry.register(panel as never, { getHtml: () => "x" });
-    registry.unregister(panel as never);
+    registry.register(panel, { getHtml: () => "x" });
+    registry.unregister(panel);
 
     let calls = 0;
     await registry.forEachVisible(() => {
@@ -47,5 +46,45 @@ suite("panelRegistry", () => {
     });
 
     assert.strictEqual(calls, 0);
+  });
+
+  test("getRegisteredViewTypes reads viewType from meta (WebviewView path)", () => {
+    const registry = new InMemoryPanelRegistry();
+    // Simulate a WebviewView which has no native viewType property.
+    const panel = makePanelHandle({ visible: true });
+
+    registry.register(panel, {
+      getHtml: () => "",
+      viewType: "molvis.pageView",
+    });
+
+    const types = registry.getRegisteredViewTypes();
+    assert.ok(types.includes("molvis.pageView"));
+  });
+
+  test("getRegisteredViewTypes falls back to panel.viewType (WebviewPanel path)", () => {
+    const registry = new InMemoryPanelRegistry();
+    const panel = makePanelHandle({ viewType: "molvis.workspace" });
+
+    registry.register(panel, { getHtml: () => "" });
+
+    const types = registry.getRegisteredViewTypes();
+    assert.ok(types.includes("molvis.workspace"));
+  });
+
+  test("forEach visits all panels regardless of visibility", async () => {
+    const registry = new InMemoryPanelRegistry();
+    const visible = makePanelHandle({ visible: true });
+    const hidden = makePanelHandle({ visible: false });
+
+    registry.register(visible, { getHtml: () => "v" });
+    registry.register(hidden, { getHtml: () => "h" });
+
+    const values: string[] = [];
+    await registry.forEach((_panel, meta) => {
+      values.push(meta.getHtml());
+    });
+
+    assert.deepStrictEqual(values.sort(), ["h", "v"]);
   });
 });


### PR DESCRIPTION
## Release 0.0.10

Ships the **vsc-ext three-surface viewer redesign + page chrome-flag system**
(implements `docs/specs/vsc-ext-surfaces.md`) and bumps all packages to 0.0.10.

Based on latest `master` (`294a302`), so it also carries the `release-python.yml`
fix (#30) — this is the first tag to publish PyPI through the corrected workflow.

## What ships

### VSCode (`vsc-ext`)
- **Activity-bar MolVis view** — the full React page now has a persistent home in
  the activity bar via a new `WebviewViewProvider` (`molvis.pageView`), registered
  with `retainContextWhenHidden` so the WebGL scene survives view collapse. New
  monochrome `molvis-activitybar.svg` icon.
- **Quick View** (lightweight core canvas) retained on the editor title bar.
- `PanelRegistry` widened to `WebviewPanel | WebviewView` so reload/settings
  broadcast to both.

### Page
- `MountOpts.surface` preset (`"full"` | `"canvas"`) + per-panel `chrome` flag
  overrides, plumbed from the VSCode host through
  `window.__MOLVIS_VSCODE_INIT__.mount`. Legacy `minimal` → alias for
  `surface: "canvas"`. New `resolveChrome()` unit tests.

## Version bump

`0.0.9 → 0.0.10` across root / core / page / vsc-ext `package.json` +
`python/pyproject.toml` (version-locked to one tag).

## Provenance / how this was assembled

The implementation was staged (uncommitted) on `dev`. Since `dev` is behind
`master` (which has the harness rebuild + the PyPI workflow fix), the staged work
was captured as a patch and re-applied cleanly onto latest `master` here — the
staged copy on `dev` is left untouched. `CLAUDE.md`'s 10-line surface-doc tweak
was intentionally dropped (master's CLAUDE.md was rebuilt by #32; the design is
already documented in `docs/specs/vsc-ext-surfaces.md`).

## Verification

- ✅ `npm run typecheck` (core + page + vsc-ext) clean on the master base
- ✅ biome: changeset clean after removing one unused import (`WebviewPanelMeta`);
  CI runs `biome check` (warnings non-blocking)
- CI will run the full suite (incl. new `mount-opts` / `panelRegistry` /
  extension-host tests) on this PR

## Release steps (yours)

After merge, push the tag to fire the release workflows:
```bash
git tag v0.0.10 && git push upstream v0.0.10
```
→ publishes core (npm), vsc-ext (Marketplace + OpenVSX), python (PyPI).

## Test plan
- [ ] CI green (lint / typecheck / test-core / vsc-ext)
- [ ] Activity-bar MolVis view opens the full page; collapse + reopen keeps the scene
- [ ] `molvis.quickView` still opens the core canvas
- [ ] `surface: "canvas"` reproduces the old `minimal` (canvas-only) behavior
