### PR TITLE
release: v0.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,11 @@ jobs:
       - name: Build core
         run: npm run build:core
 
+      # Pack gate: ban inspector/gui-editor/loaders in dist and enforce the
+      # CDN elements size budget. Catches the 0.0.11 multi-MB debug-UI leak.
+      - name: Check pack surface
+        run: npm run check:pack
+
   build-page:
     runs-on: ubuntu-latest
     needs: [lint, typecheck]

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -36,5 +36,8 @@ jobs:
       - name: Build core
         run: npm run build:core
 
+      - name: Check pack surface
+        run: npm run check:pack
+
       - name: Publish to npm (Trusted Publisher, OIDC)
         run: npm publish -w core --provenance --access public

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,16 @@ repos:
         always_run: true
         stages: [pre-push]
 
+      # Fails if dist/ reintroduces inspector/gui-editor/loaders or the CDN
+      # elements surface exceeds the size budget (the 0.0.11 regression).
+      - id: check-pack
+        name: check pack (no inspector / elements budget)
+        entry: npm run check:pack
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
+
       - id: build-page
         name: build page (rsbuild)
         entry: npm run build:page

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@molcrafts/molvis-core",
-  "version": "0.0.11",
+  "version": "0.1.0",
   "type": "module",
   "exports": {
     ".": {
@@ -70,7 +70,7 @@
     "@babylonjs/gui": "^9.10.1",
     "@babylonjs/materials": "^9.10.1",
     "@babylonjs/serializers": "^9.10.1",
-    "@molcrafts/molrs": "^0.8.0",
+    "@molcrafts/molrs": "^0.8.2",
     "tslog": "^4.10.2"
   },
   "directories": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,8 @@
     "test:headless": "npm run build:headless && node scripts/headless_render_runner.mjs --dist examples-dist/headless --specs examples/headless_smoke.json --outdir examples-dist/headless-smoke",
     "test:watch": "rstest watch",
     "bench": "rstest run -c rstest.bench.config.ts",
-    "release:check": "npm run build && npm run test && npm_config_cache=/tmp/npm-cache npm pack --dry-run"
+    "release:check": "npm run build && npm run test && npm run check:pack && npm_config_cache=/tmp/npm-cache npm pack --dry-run",
+    "check:pack": "node ./scripts/check_pack.mjs"
   },
   "devDependencies": {
     "@rsbuild/core": "^2.0.8",
@@ -67,7 +68,6 @@
   "dependencies": {
     "@babylonjs/core": "^9.10.1",
     "@babylonjs/gui": "^9.10.1",
-    "@babylonjs/inspector": "^9.10.1",
     "@babylonjs/materials": "^9.10.1",
     "@babylonjs/serializers": "^9.10.1",
     "@molcrafts/molrs": "^0.8.0",

--- a/core/rslib.config.ts
+++ b/core/rslib.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "@rslib/core";
+import { rspack } from "@rspack/core";
 
 /**
  * Library build for `@molcrafts/molvis-core`.
@@ -11,7 +12,30 @@ import { defineConfig } from "@rslib/core";
  * the `.wasm` module the same way rsbuild app / vsc-ext builds do. Without it,
  * glue ships with an uninitialized `let wasm` and `new Frame()` throws
  * `Cannot read properties of undefined (reading 'frame_new')`.
+ *
+ * Inspector / gui-editor are banned from the product: they are multi-MB debug
+ * UIs molvis never ships. The unbundled library build externals them (so a
+ * stray import fails at package-resolution time), and the CDN `elements`
+ * bundle IgnorePlugin-strips them so a stale dynamic import cannot reintroduce
+ * the weight as async chunks.
  */
+const BABYLON_RUNTIME_EXTERNALS = [
+  "@babylonjs/core",
+  "@babylonjs/gui",
+  "@babylonjs/materials",
+  "@molcrafts/molrs",
+  "tslog",
+] as const;
+
+/** Debug-only Babylon packages that must never land in molvis-core dist. */
+const BABYLON_BANNED = [
+  "@babylonjs/inspector",
+  "@babylonjs/gui-editor",
+  // loaders are only pulled by inspector / editor tooling, not by molvis
+  // render path. glTF *export* uses @babylonjs/serializers (kept).
+  "@babylonjs/loaders",
+] as const;
+
 export default defineConfig({
   lib: [
     {
@@ -24,14 +48,7 @@ export default defineConfig({
       output: {
         // rsbuild "web" = browser runtime environment, NOT wasm-pack --target web
         target: "web",
-        externals: [
-          "@babylonjs/core",
-          "@babylonjs/gui",
-          "@babylonjs/inspector",
-          "@babylonjs/materials",
-          "@molcrafts/molrs",
-          "tslog",
-        ],
+        externals: [...BABYLON_RUNTIME_EXTERNALS, ...BABYLON_BANNED],
       },
     },
     {
@@ -58,6 +75,17 @@ export default defineConfig({
             ...config.output,
             publicPath: "auto",
           };
+          // Belt-and-suspenders: even a residual `import("@babylonjs/inspector")`
+          // must not emit multi-MB async chunks into dist/.
+          const ban = BABYLON_BANNED.map((name) =>
+            name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+          ).join("|");
+          config.plugins = [
+            ...(config.plugins ?? []),
+            new rspack.IgnorePlugin({
+              resourceRegExp: new RegExp(ban),
+            }),
+          ];
         },
       },
     },

--- a/core/scripts/check_pack.mjs
+++ b/core/scripts/check_pack.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * Post-build pack gate for `@molcrafts/molvis-core`.
+ *
+ * Catches the class of failure that shipped in 0.0.11: the CDN `elements`
+ * entry bundled Babylon Inspector / gui-editor (multi-MB debug UI that molvis
+ * never uses) because a dynamic import survived into the rspack graph and
+ * neither CI nor pre-commit looked at the published tarball contents.
+ *
+ * Invoked by `npm run check:pack` / `release:check`. Failures are hard —
+ * do not publish with banned packages or a bloated elements surface.
+ */
+import { readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const DIST = path.join(ROOT, "dist");
+
+/**
+ * Budget for the whole elements CDN surface (entry + async chunks + wasm).
+ * 0.0.11 shipped ~38MB of JS alone because of inspector; a healthy build
+ * with core/gui/materials/molrs should land well under this.
+ */
+const ELEMENTS_TOTAL_BUDGET_BYTES = 25 * 1024 * 1024;
+
+/**
+ * Hard ban on Babylon debug-tooling artifact names.
+ * Deliberately does NOT match `data_inspector` (our own frame-table panel).
+ */
+const BANNED_FILE_RE =
+  /(?:^|[/\\])(?:1~)?(?:@babylonjs\/)?(?:inspector|gui-editor)(?:[/\\.]|$)|babylon\.guiEditor|guiEditor/i;
+
+async function walk(dir) {
+  /** @type {string[]} */
+  const out = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    if (err && err.code === "ENOENT") {
+      throw new Error(
+        `dist/ missing — run \`npm run build\` before check:pack (${DIST})`,
+      );
+    }
+    throw err;
+  }
+  for (const ent of entries) {
+    const full = path.join(dir, ent.name);
+    if (ent.isDirectory()) {
+      out.push(...(await walk(full)));
+    } else {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function rel(file) {
+  return path.relative(DIST, file).split(path.sep).join("/");
+}
+
+async function main() {
+  const files = await walk(DIST);
+  /** @type {string[]} */
+  const errors = [];
+  /** @type {string[]} */
+  const warnings = [];
+
+  // 1. Banned path names
+  for (const file of files) {
+    const r = rel(file);
+    if (BANNED_FILE_RE.test(r)) {
+      errors.push(`banned artifact in dist/: ${r}`);
+    }
+  }
+
+  // 2. Banned content in JS (catches re-exports / dynamic import strings)
+  const bannedContent = [
+    /@babylonjs\/inspector\b/,
+    /@babylonjs\/gui-editor\b/,
+    /@babylonjs\/loaders\b/,
+    /babylon\.guiEditor/,
+  ];
+  for (const file of files) {
+    if (!file.endsWith(".js")) continue;
+    const r = rel(file);
+    if (r.endsWith(".LICENSE.txt")) continue;
+    const text = await readFile(file, "utf8");
+    for (const re of bannedContent) {
+      if (re.test(text)) {
+        errors.push(`banned package reference in ${r} (${re})`);
+        break;
+      }
+    }
+  }
+
+  // 3. elements entry must exist and not be an empty stub without its graph
+  const elementsEntry = path.join(DIST, "elements.js");
+  try {
+    const st = await stat(elementsEntry);
+    if (st.size === 0) {
+      errors.push("dist/elements.js is empty");
+    }
+  } catch {
+    errors.push("dist/elements.js missing — elements CDN entry did not build");
+  }
+
+  // 4. Size budget over JS+wasm under dist that the CDN entry can pull
+  //    (everything except .d.ts / LICENSE). This is a regression tripwire,
+  //    not a perfect tree-shaker.
+  let total = 0;
+  for (const file of files) {
+    if (file.endsWith(".d.ts") || file.endsWith(".LICENSE.txt")) continue;
+    if (!/\.(js|wasm|mjs)$/.test(file)) continue;
+    // Unbundled library modules (app.js, world.js, …) are external-deps for
+    // npm consumers and are not loaded by the CDN elements entry. Only count
+    // the bundled elements surface: elements.js, numeric chunk ids, `1~*`,
+    // and static/wasm.
+    const r = rel(file);
+    const isElementsSurface =
+      r === "elements.js" ||
+      /^[0-9]+\.js$/.test(r) ||
+      r.startsWith("1~") ||
+      r.startsWith("static/");
+    if (!isElementsSurface) continue;
+    total += (await stat(file)).size;
+  }
+  if (total > ELEMENTS_TOTAL_BUDGET_BYTES) {
+    errors.push(
+      `elements CDN surface is ${(total / 1024 / 1024).toFixed(1)}MB ` +
+        `(budget ${(ELEMENTS_TOTAL_BUDGET_BYTES / 1024 / 1024).toFixed(0)}MB) — ` +
+        `debug tooling or accidental deps likely reintroduced`,
+    );
+  } else {
+    warnings.push(
+      `elements CDN surface: ${(total / 1024 / 1024).toFixed(1)}MB ` +
+        `(budget ${(ELEMENTS_TOTAL_BUDGET_BYTES / 1024 / 1024).toFixed(0)}MB)`,
+    );
+  }
+
+  for (const w of warnings) {
+    console.log(`check:pack warn: ${w}`);
+  }
+  if (errors.length) {
+    console.error("check:pack FAILED:");
+    for (const e of errors) console.error(`  - ${e}`);
+    process.exit(1);
+  }
+  console.log("check:pack ok");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/core/src/world.ts
+++ b/core/src/world.ts
@@ -9,8 +9,6 @@ import {
   Tools,
   Vector3,
 } from "@babylonjs/core";
-// Inspector is lazy-loaded to avoid bundling 17MB in the main chunk
-// import { Inspector } from "@babylonjs/inspector";
 import type { MolvisApp } from "./app";
 import { AxisHelper } from "./axis_helper";
 import { CameraAnimator } from "./camera/animator";
@@ -304,16 +302,16 @@ export class World {
     this._engine.stopRenderLoop(this._renderLoop);
   }
 
-  public async toggleInspector() {
-    const scene = this.scene;
-    if (scene.debugLayer.isVisible()) {
-      scene.debugLayer.hide();
-      return;
-    }
-    const { Inspector } = await import("@babylonjs/inspector");
-    Inspector.Show(scene, {
-      embedMode: true,
-    });
+  /**
+   * Historical "I" hotkey entry. Babylon's Inspector/gui-editor stack is
+   * deliberately not a dependency of molvis-core (it was pulling ~10MB of
+   * debug UI into the CDN `elements` bundle). Kept as a no-op so mode
+   * keyboard handlers do not need a special case.
+   */
+  public async toggleInspector(): Promise<void> {
+    logger.warn(
+      "[World] Babylon Inspector is not shipped with molvis-core; ignoring toggle",
+    );
   }
 
   /**

--- a/docs/interfaces/web/install.md
+++ b/docs/interfaces/web/install.md
@@ -34,7 +34,7 @@ npm (jsDelivr):
 ```html
 <script
   type="module"
-  src="https://cdn.jsdelivr.net/npm/@molcrafts/molvis-core@0.0.11/dist/elements.js"
+  src="https://cdn.jsdelivr.net/npm/@molcrafts/molvis-core@0.1.0/dist/elements.js"
 ></script>
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "molvis",
-  "version": "0.0.11",
+  "version": "0.1.0",
   "description": "interactive molecule visulization package",
   "author": "Roy Kid",
   "license": "BSD-3-Clause",
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@molcrafts/molplot": "^0.1.1",
-    "@molcrafts/molrs": "^0.8.0",
+    "@molcrafts/molrs": "^0.8.2",
     "vega": "^5.30.0",
     "vega-embed": "^6.29.0",
     "vega-lite": "^5.21.0"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test": "npm run test:core && npm run test:page && npm run test:python && npm run test:vsc-ext",
     "test:watch": "npm run test:watch -w core",
     "release:core:check": "npm run release:check -w core",
+    "check:pack": "npm run check:pack -w core",
     "lint": "biome check --write"
   },
   "devDependencies": {

--- a/page/package.json
+++ b/page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "page",
-  "version": "0.0.11",
+  "version": "0.1.0",
   "main": "index.js",
   "type": "module",
   "keywords": [],

--- a/page/rsbuild.config.ts
+++ b/page/rsbuild.config.ts
@@ -34,9 +34,10 @@ export default defineConfig({
       splitChunks: {
         chunks: "all",
         cacheGroups: {
-          // BabylonJS core/gui/materials — sync, cached separately (large, stable)
+          // BabylonJS core/gui/materials — sync, cached separately (large, stable).
+          // serializers is lazy (glTF export); inspector is not a dependency.
           babylonjs: {
-            test: /[\\/]node_modules[\\/]@babylonjs[\\/](?!inspector)/,
+            test: /[\\/]node_modules[\\/]@babylonjs[\\/](?!serializers)/,
             name: "lib-babylonjs",
             chunks: "initial",
             priority: 20,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "molcrafts-molvis"
-version = "0.0.11"
+version = "0.1.0"
 description = "Molecular visualization driven by a local WebSocket-hosted page"
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -24,7 +24,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization",
 ]
 dependencies = [
-    "molcrafts-molpy>=0.8.0",
+    "molcrafts-molpy>=0.8.2",
     "numpy",
     "websockets>=13.0",
 ]

--- a/vsc-ext/package.json
+++ b/vsc-ext/package.json
@@ -12,7 +12,7 @@
   },
   "license": "BSD-3-Clause",
   "icon": "image/molvis-icon.png",
-  "version": "0.0.11",
+  "version": "0.1.0",
   "engines": {
     "vscode": "^1.120.0"
   },

--- a/vsc-ext/rslib.webview.config.mts
+++ b/vsc-ext/rslib.webview.config.mts
@@ -146,18 +146,13 @@ export default defineConfig({
               enforce: true,
               chunks: "async",
             },
-            // The Babylon Inspector is a debug-only panel, lazy-loaded via
-            // `import("@babylonjs/inspector")` (see core/src/world.ts) and it
-            // drags in @babylonjs/loaders + serializers (the whole glTF stack).
-            // Same `chunks:"all"` hoisting bug as plotly: without this group it
-            // lands in the synchronous vendor chunk, so every opened file pays
-            // for several MB of debug tooling it never touches. Keep it async so
-            // it only loads when the user actually toggles the inspector.
-            // (@babylonjs/gui + materials are used at render time and stay in
-            // vendor — they are intentionally not listed here.)
-            babylonInspector: {
-              name: "chunks/babylon-inspector",
-              test: /[\\/]node_modules[\\/]@babylonjs[\\/](inspector|loaders|serializers)[\\/]/,
+            // glTF export is lazy (`import("@babylonjs/serializers")`); keep it
+            // async so the initial webview does not pay for the serializer
+            // stack. Inspector / gui-editor / loaders are not dependencies of
+            // molvis-core at all.
+            babylonSerializers: {
+              name: "chunks/babylon-serializers",
+              test: /[\\/]node_modules[\\/]@babylonjs[\\/]serializers[\\/]/,
               priority: 55,
               enforce: true,
               chunks: "async",


### PR DESCRIPTION
## Summary
- **v0.0.11 → v0.1.0** minor release
- Pin `@molcrafts/molrs` / `molcrafts-molpy` to **0.8.2**
- Slim CDN `elements` bundle: drop Babylon inspector/gui-editor (~38MB → ~20MB)
- `check:pack` gate so debug UI cannot re-enter the published package

## Test plan
- [x] local pre-push gate (biome, typecheck, tests, builds, check:pack)
- [ ] CI on the PR