### PR TITLE
release: v0.1.1

### DIFF
--- a/core/examples/headless_render.ts
+++ b/core/examples/headless_render.ts
@@ -164,7 +164,7 @@ function buildFrame(spec: RenderSceneSpec): Frame {
     const grid = frame.createBlock("grid");
     grid.setColF("density", Float64Array.from(density));
     grid.setShape(Uint32Array.from(spec.grid.shape));
-    frame.simbox = Box.cube(
+    frame.box = Box.cube(
       new Float64Array([spec.grid.boxLength ?? 10]),
       new Float64Array([0, 0, 0]),
       false,

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@molcrafts/molvis-core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "exports": {
     ".": {
@@ -70,7 +70,7 @@
     "@babylonjs/gui": "^9.10.1",
     "@babylonjs/materials": "^9.10.1",
     "@babylonjs/serializers": "^9.10.1",
-    "@molcrafts/molrs": "^0.8.2",
+    "@molcrafts/molrs": "0.9.0",
     "tslog": "^4.10.2"
   },
   "directories": {

--- a/core/src/analysis/frame_subset.ts
+++ b/core/src/analysis/frame_subset.ts
@@ -45,8 +45,8 @@ export function buildAtomSubFrame(
   const subFrame = new FrameClass();
   subFrame.insertBlock("atoms", subBlock);
 
-  const simbox = frame.simbox;
-  if (simbox) subFrame.simbox = simbox;
+  const box = frame.box;
+  if (box) subFrame.box = box;
 
   return subFrame;
 }

--- a/core/src/analysis/rdf.ts
+++ b/core/src/analysis/rdf.ts
@@ -17,7 +17,7 @@ export interface RdfParams {
   /** Indices for cross-RDF second group. If omitted, uses groupA (self-RDF). */
   groupB?: number[];
   /**
-   * Normalization volume in Å³. Required for non-periodic frames (no simbox).
+   * Normalization volume in Å³. Required for non-periodic frames (no box).
    * For periodic frames, overrides the box volume if provided.
    */
   volume?: number;
@@ -51,8 +51,8 @@ const DEFAULT_R_MIN = 0;
  * Compute the radial distribution function g(r) from a single frame.
  *
  * Follows freud defaults: `nBins = 100`, `rMin = 0`, normalize by the
- * system density `N/V`. Periodic frames take their volume from `frame.simbox`.
- * Non-periodic frames (no simbox) require the caller to pass `volume`
+ * system density `N/V`. Periodic frames take their volume from `frame.box`.
+ * Non-periodic frames (no box) require the caller to pass `volume`
  * explicitly — no bounding box is fabricated.
  *
  * Group selection:
@@ -108,7 +108,7 @@ interface RdfRunOpts {
   volumeOverride: number | null;
 }
 
-/** Returns the explicit volume, or null to defer to `frame.simbox`. Throws if neither is available or the explicit value is invalid. */
+/** Returns the explicit volume, or null to defer to `frame.box`. Throws if neither is available or the explicit value is invalid. */
 function resolveVolume(
   frame: Frame,
   paramVolume: number | undefined,
@@ -121,7 +121,7 @@ function resolveVolume(
     }
     return paramVolume;
   }
-  if (!frame.simbox) {
+  if (!frame.box) {
     throw new Error(
       "RDF: frame has no simulation box — pass an explicit `volume` (Å³)",
     );
@@ -138,7 +138,7 @@ function runWasmRdf(
   let rdfObj: WasmRDF | null = null;
   try {
     // The normalization volume is constructor state: an RDF built with one
-    // normalizes by it, an RDF built without one reads `frame.simbox`.
+    // normalizes by it, an RDF built without one reads `frame.box`.
     rdfObj = new WasmRDF(opts.nBins, opts.rMax, opts.rMin, opts.volumeOverride);
     const wasmResult =
       opts.volumeOverride !== null

--- a/core/src/analysis/utils.ts
+++ b/core/src/analysis/utils.ts
@@ -5,16 +5,16 @@ import { viewAtomCoords } from "../io/atom_coords";
  * Estimate a reasonable rMax cutoff from frame geometry.
  * Periodic: min(box lengths) / 2.  Non-periodic: sampled max distance / 2.
  *
- * @param frame - Frame with atoms block (and optionally simbox).
+ * @param frame - Frame with atoms block (and optionally box).
  * @returns Estimated rMax in angstrom, or 0 if frame has no usable data.
  */
 export function estimateRMax(frame: Frame): number {
-  const box = frame.simbox;
+  const box = frame.box;
   if (box) {
     const lengths = box.lengths();
     const L = lengths.toCopy();
     lengths.free();
-    // Do NOT free box — freeing a simbox/getBlock handle corrupts the frame's
+    // Do NOT free box — freeing a box/getBlock handle corrupts the frame's
     // shared data on subsequent reads (see memory: project_molrs_handle_ownership).
     return Math.min(L[0], L[1], L[2]) / 2;
   }

--- a/core/src/app.ts
+++ b/core/src/app.ts
@@ -950,7 +950,7 @@ export class MolvisApp {
     this._world.sceneIndex.markAllSaved();
     this.events.emit("frame-rendered", {
       frame: renderTarget,
-      box: renderTarget.simbox ?? undefined,
+      box: renderTarget.box ?? undefined,
     });
 
     // Unified selection sync — single path, no duplication

--- a/core/src/artist.ts
+++ b/core/src/artist.ts
@@ -108,7 +108,7 @@ function computeBondMIDisplacements(
   atomsBlock: Block,
   bondsBlock: Block,
 ): Float64Array | undefined {
-  const box = frame.simbox;
+  const box = frame.box;
   if (!box) return undefined;
   const nbonds = bondsBlock.nrows();
   if (nbonds === 0) return undefined;

--- a/core/src/artist/isosurface/isosurface_renderer.ts
+++ b/core/src/artist/isosurface/isosurface_renderer.ts
@@ -198,10 +198,10 @@ export class IsosurfaceRenderer {
     }
     if (!data) return;
 
-    const box = frame.simbox;
+    const box = frame.box;
     if (!box) {
       logger.warn(
-        "[Isosurface] frame has no simbox; cannot place voxels in world space",
+        "[Isosurface] frame has no box; cannot place voxels in world space",
       );
       return;
     }

--- a/core/src/axis_helper.ts
+++ b/core/src/axis_helper.ts
@@ -8,6 +8,7 @@ import {
   Mesh,
   MeshBuilder,
   type Observer,
+  Quaternion,
   type Scene,
   StandardMaterial,
   Vector3,
@@ -17,6 +18,9 @@ import {
 const AXIS_VIEWPORT_BASE_FRACTION = 0.15;
 const AXIS_VIEWPORT_SCALE = 1.2;
 const AXIS_VIEWPORT_PADDING_FRACTION = 10 / 150;
+
+/** Local cylinder axis before pivot alignment (Babylon cylinders grow along +Y). */
+const CYLINDER_LOCAL_UP = new Vector3(0, 1, 0);
 
 /**
  * Build a square, canvas-relative axis-helper viewport.
@@ -44,11 +48,16 @@ export function axisHelperViewport(
 
 /**
  * AxisViewer - A custom 3D axis gizmo with arrows and labels.
- * Replaces default AxesViewer for better aesthetics.
+ *
+ * Axes use explicit world directions (+X/+Y/+Z) via quaternion alignment.
+ * Labels are re-oriented every frame from the gizmo camera basis (not
+ * BILLBOARDMODE_ALL) so the Z glyph cannot pick up a billboard singularity
+ * reflection when the tip sits near camera-up.
  */
 class AxisViewer {
   private _scene: Scene;
   private _root: Mesh;
+  private _labels: Mesh[] = [];
 
   constructor(scene: Scene, size = 1) {
     this._scene = scene;
@@ -56,39 +65,31 @@ class AxisViewer {
 
     const chordLength = size * 0.1;
     const arrowHeight = size * 0.25;
-    const shaftHeight = size - arrowHeight;
     const shaftDiameter = size * 0.05;
 
-    // X Axis (Red)
+    // Right-handed, Z-up world: +X red, +Y green, +Z blue.
     this.createAxis(
       "X",
       Color3.Red(),
-      new Vector3(shaftHeight / 2 + arrowHeight, 0, 0), // Position? No, cylinder centers
-      new Vector3(0, 0, -Math.PI / 2),
+      new Vector3(1, 0, 0),
       size,
       shaftDiameter,
       arrowHeight,
       chordLength,
     );
-
-    // Y Axis (Green)
     this.createAxis(
       "Y",
       Color3.Green(),
-      new Vector3(0, size, 0),
-      Vector3.Zero(),
+      new Vector3(0, 1, 0),
       size,
       shaftDiameter,
       arrowHeight,
       chordLength,
     );
-
-    // Z Axis (Blue)
     this.createAxis(
       "Z",
       Color3.Blue(),
-      new Vector3(0, 0, size),
-      new Vector3(Math.PI / 2, 0, 0),
+      new Vector3(0, 0, 1),
       size,
       shaftDiameter,
       arrowHeight,
@@ -96,11 +97,46 @@ class AxisViewer {
     );
   }
 
+  /**
+   * Face every label at the gizmo camera, upright w.r.t. camera up.
+   *
+   * `MeshBuilder.CreatePlane` has its front face along **local −Z** (normals
+   * are (0,0,−1)). `FromLookDirectionRH(forward)` aims local **+Z** along
+   * `forward`, so `forward` must point **away from the camera** — otherwise
+   * the front face is culled and the letters vanish.
+   */
+  public orientLabels(camera: ArcRotateCamera): void {
+    const camPos = camera.position;
+    const camUp = camera.upVector;
+    for (const label of this._labels) {
+      // Root is identity, but use absolute position so parenting stays safe.
+      const worldPos = label.getAbsolutePosition();
+      const awayFromCam = worldPos.subtract(camPos);
+      if (awayFromCam.lengthSquared() < 1e-12) continue;
+      const forward = awayFromCam.normalize();
+
+      // When looking nearly along ±camera-up (Z label near the pole), pick a
+      // stable alternate up so FromLookDirectionRH does not collapse.
+      let up = camUp;
+      if (Math.abs(Vector3.Dot(forward, camUp)) > 0.98) {
+        up = Math.abs(camUp.y) < 0.9 ? Vector3.Up() : Vector3.Right();
+      }
+
+      if (!label.rotationQuaternion) {
+        label.rotationQuaternion = new Quaternion();
+      }
+      Quaternion.FromLookDirectionRHToRef(
+        forward,
+        up,
+        label.rotationQuaternion,
+      );
+    }
+  }
+
   private createAxis(
     label: string,
     color: Color3,
-    _direction: Vector3, // Not used directly, we rotate
-    rotation: Vector3,
+    direction: Vector3,
     totalLength: number,
     shaftDiameter: number,
     arrowHeight: number,
@@ -111,20 +147,20 @@ class AxisViewer {
     material.emissiveColor = color.scale(0.8);
     material.specularColor = Color3.Black();
 
-    // Shaft
+    const shaftLen = totalLength - arrowHeight;
+
     const shaft = MeshBuilder.CreateCylinder(
       `shaft${label}`,
       {
-        height: totalLength - arrowHeight,
+        height: shaftLen,
         diameter: shaftDiameter,
         tessellation: 16,
       },
       this._scene,
     );
     shaft.material = material;
-    shaft.position.y = (totalLength - arrowHeight) / 2;
+    shaft.position.y = shaftLen / 2;
 
-    // Arrow Cap (Cone)
     const arrow = MeshBuilder.CreateCylinder(
       `arrow${label}`,
       {
@@ -138,57 +174,43 @@ class AxisViewer {
     arrow.material = material;
     arrow.position.y = totalLength - arrowHeight / 2;
 
-    // Group Shaft + Arrow into Pivot for rotation
     const pivot = new Mesh(`pivot${label}`, this._scene);
     shaft.parent = pivot;
     arrow.parent = pivot;
 
-    pivot.rotation = rotation;
+    const dir = direction.clone().normalize();
+    pivot.rotationQuaternion = Quaternion.FromUnitVectorsToRef(
+      CYLINDER_LOCAL_UP,
+      dir,
+      new Quaternion(),
+    );
     pivot.parent = this._root;
 
-    // LABEL (Separate, not rotated, to ensure billboard works upright)
-    // Calculate dimensions
     const labelOffset = totalLength + 0.35;
-    // Transform the local "up" vector (0,1,0) by the rotation to find axis tip direction
-    // Then scale by offset
-    const directionVec = new Vector3(0, 1, 0);
-
-    // Apply rotation (Euler)
-    const rotationMatrix = BABYLON.Matrix.RotationYawPitchRoll(
-      rotation.y,
-      rotation.x,
-      rotation.z,
-    );
-    const finalPos = Vector3.TransformCoordinates(
-      directionVec.scale(labelOffset),
-      rotationMatrix,
-    );
-
     const labelMesh = this.createLabel(label, color.toHexString());
-    if (label === "Z") {
-      // Correct the Z glyph's roll in the right-handed billboard scene.
-      labelMesh.rotation.z = Math.PI;
-    }
-    labelMesh.position = finalPos;
+    labelMesh.position = dir.scale(labelOffset);
     labelMesh.parent = this._root;
+    this._labels.push(labelMesh);
   }
 
   private createLabel(text: string, color: string) {
-    const size = 0.8; // Larger plane
-    const font = "bold 80px Arial"; // Crisper font
+    const size = 0.8;
+    const font = "bold 80px Arial";
 
     const dynamicTexture = new DynamicTexture(
       `axisLabelTexture${text}`,
-      128,
+      { width: 128, height: 128 },
       this._scene,
       true,
     );
     dynamicTexture.hasAlpha = true;
     dynamicTexture.drawText(text, null, null, font, color, "transparent", true);
 
+    // DOUBLESIDE: even if look-direction is briefly wrong for one frame, the
+    // glyph stays visible. Front face is local −Z (see orientLabels).
     const plane = MeshBuilder.CreatePlane(
       `axisLabel${text}`,
-      { size },
+      { size, sideOrientation: Mesh.DOUBLESIDE },
       this._scene,
     );
     const material = new StandardMaterial(
@@ -198,12 +220,18 @@ class AxisViewer {
     material.backFaceCulling = false;
     material.emissiveColor = Color3.White();
     material.diffuseTexture = dynamicTexture;
-    material.disableLighting = true; // Always visible
+    material.opacityTexture = dynamicTexture;
+    material.disableLighting = true;
+    material.useAlphaFromDiffuseTexture = true;
     plane.material = material;
 
-    plane.billboardMode = Mesh.BILLBOARDMODE_ALL;
-    // In the right-handed gizmo scene, billboard text appears mirrored without an X flip.
+    plane.rotationQuaternion = Quaternion.Identity();
+    // RH: viewing the plane front (local −Z toward camera) mirrors local +X
+    // on screen, so a drawn "Z" shows as Ƨ (diagonal / instead of \). Flip X.
     plane.scaling.x = -1;
+    // Disable frustum culling: labels sit in a tiny corner viewport and can
+    // otherwise be culled against the full-canvas frustum.
+    plane.alwaysSelectAsActiveMesh = true;
 
     return plane;
   }
@@ -218,11 +246,13 @@ export class AxisHelper {
   private _cameraGizmo: BABYLON.ArcRotateCamera;
   private _engine: BABYLON.Engine;
   private _resizeObserver: Observer<AbstractEngine>;
+  private _viewer: AxisViewer;
 
   public constructor(engine: BABYLON.Engine, camera: ArcRotateCamera) {
     this._engine = engine;
     const scene = new BABYLON.Scene(engine);
     this._scene = scene;
+    // Match the main World scene: right-handed + Z-up.
     scene.useRightHandedSystem = true;
     scene.autoClear = false;
 
@@ -234,23 +264,25 @@ export class AxisHelper {
       Vector3.Zero(),
       scene,
     );
+    // Must set upVector before first render so alpha/beta map onto Z-up.
     this._cameraGizmo.upVector = camera.upVector.clone();
 
     new HemisphericLight("lightAxis", new Vector3(0, 0, 1), scene);
 
-    new AxisViewer(scene, 2.5);
+    this._viewer = new AxisViewer(scene, 2.5);
 
     // Initial setup
     this.updateViewport();
+    // Orient once immediately so the first frame is not blank.
+    this._viewer.orientLabels(this._cameraGizmo);
 
-    // Sync camera on render
+    // Sync gizmo camera + label orientation every frame.
     scene.registerBeforeRender(() => {
-      if (camera) {
-        this._cameraGizmo.upVector.copyFrom(camera.upVector);
-        this._cameraGizmo.alpha = camera.alpha;
-        this._cameraGizmo.beta = camera.beta;
-        // Keep radius fixed
-      }
+      if (!camera) return;
+      this._cameraGizmo.upVector.copyFrom(camera.upVector);
+      this._cameraGizmo.alpha = camera.alpha;
+      this._cameraGizmo.beta = camera.beta;
+      this._viewer.orientLabels(this._cameraGizmo);
     });
 
     // Follow the actual render-canvas size, including container-only resizes.

--- a/core/src/camera/fit.ts
+++ b/core/src/camera/fit.ts
@@ -106,15 +106,24 @@ function absDot(a: Vec3, b: Vec3): number {
 
 /**
  * Screen basis (right/up/forward) of a Z-up `ArcRotateCamera` at the given
- * angles. The camera sits at `target + radius·dir` with
- * `dir = (sinβcosα, sinβsinα, cosβ)`; `forward = -dir`. When `forward` is
- * (anti)parallel to world-up the right vector is derived from the Y axis to
- * stay finite.
+ * angles.
+ *
+ * Babylon's Z-up spherical mapping (verified against ArcRotateCamera with
+ * `upVector = (0,0,1)`) is:
+ * ```
+ * dir = (sinβ · cosα, −sinβ · sinα, cosβ)
+ * ```
+ * Note the **minus on Y** — the Y-up textbook formula `(…, +sinβ·sinα, …)` is
+ * wrong here and previously sent auto-view / fit to the opposite Y hemisphere,
+ * which looks like a flipped Z axis relative to the data.
+ *
+ * `forward = −dir`. When `forward` is (anti)parallel to world-up the right
+ * vector is derived from the Y axis to stay finite.
  */
 export function viewBasis(alpha: number, beta: number): ViewBasis {
   const dir: Vec3 = [
     Math.sin(beta) * Math.cos(alpha),
-    Math.sin(beta) * Math.sin(alpha),
+    -Math.sin(beta) * Math.sin(alpha),
     Math.cos(beta),
   ];
   const forward: Vec3 = [-dir[0], -dir[1], -dir[2]];
@@ -129,7 +138,8 @@ export function viewBasis(alpha: number, beta: number): ViewBasis {
 export function anglesFromForward(forward: Vec3): ViewAngles {
   const dir: Vec3 = [-forward[0], -forward[1], -forward[2]];
   const beta = Math.acos(Math.min(1, Math.max(-1, dir[2])));
-  const alpha = Math.atan2(dir[1], dir[0]);
+  // Invert the −sinβ·sinα mapping: sinα = −dir.y / sinβ → α = atan2(−dir.y, dir.x).
+  const alpha = Math.atan2(-dir[1], dir[0]);
   return { alpha, beta };
 }
 

--- a/core/src/commands/frame.ts
+++ b/core/src/commands/frame.ts
@@ -120,7 +120,7 @@ export class UpdateFrameCommand extends Command<UpdateFrameResult> {
     }
 
     // NOTE: frameAtoms/frameBonds are getBlock wrappers and are deliberately
-    // NOT freed — freeing a getBlock/simbox handle corrupts the frame's shared
+    // NOT freed — freeing a getBlock/box handle corrupts the frame's shared
     // data on subsequent reads (see memory: project_molrs_handle_ownership).
     // Internal buffer checks inside updateAtomBuffer / updateBondBuffer still
     // throw on soft failures (buffer missing, frame offset mismatch). Translate

--- a/core/src/element.ts
+++ b/core/src/element.ts
@@ -117,11 +117,25 @@ function directSourceTemplate(element: Element): HTMLTemplateElement | null {
   return null;
 }
 
+/**
+ * Normalize inline molecular text from a `<template data-molvis-source>`.
+ * Drops BOM and leading/trailing blank lines so XYZ `len()` (molrs ≤0.8.2)
+ * never treats pretty-print indentation as a second frame header.
+ */
+export function normalizeInlineSource(text: string | null | undefined): string {
+  if (!text) return "";
+  const lines = text.replace(/^\uFEFF/, "").split(/\r?\n/);
+  while (lines.length > 0 && lines[0].trim() === "") lines.shift();
+  while (lines.length > 0 && lines[lines.length - 1].trim() === "") lines.pop();
+  return lines.join("\n");
+}
+
 /** Parse and validate the author-facing attributes and inline source. */
 export function parseMolvisViewer(element: Element): MolvisViewerOptions {
   const src = element.getAttribute("src")?.trim() || undefined;
   const template = directSourceTemplate(element);
-  const content = template?.content.textContent ?? undefined;
+  const raw = template?.content.textContent ?? undefined;
+  const content = raw === undefined ? undefined : normalizeInlineSource(raw);
   if (src && template) {
     throw new Error(
       "molvis-viewer accepts either src or inline source, not both.",
@@ -189,7 +203,8 @@ export function parseMolvisStyleGallery(
 ): MolvisStyleGalleryOptions {
   const src = element.getAttribute("src")?.trim() || undefined;
   const template = directSourceTemplate(element);
-  const content = template?.content.textContent ?? undefined;
+  const raw = template?.content.textContent ?? undefined;
+  const content = raw === undefined ? undefined : normalizeInlineSource(raw);
   if (src && template) {
     throw new Error(
       "molvis-style-gallery accepts either src or inline source, not both.",

--- a/core/src/io/formats.ts
+++ b/core/src/io/formats.ts
@@ -91,7 +91,7 @@ export const FILE_FORMAT_REGISTRY: readonly FileFormatDescriptor[] = [
     format: "cif",
     label: "Crystallographic Information File",
     description:
-      "IUCr CIF / mmCIF — atomic coordinates plus unit cell that becomes simbox (.cif, .mmcif)",
+      "IUCr CIF / mmCIF — atomic coordinates plus unit cell that becomes frame.box (.cif, .mmcif)",
     extensions: ["cif", "mmcif"],
     payload: "text",
     streaming: "eager-only",

--- a/core/src/io/normalize_coords.ts
+++ b/core/src/io/normalize_coords.ts
@@ -46,7 +46,7 @@ function pickSource(block: Block, axis: Axis): string | undefined {
  * included) before being written back as `x/y/z`.
  *
  * Throws when coordinates are absent entirely, when scaled coords are
- * present without a simbox, or when a partially-scaled/partially-real mix
+ * present without a box, or when a partially-scaled/partially-real mix
  * is encountered (that combination has no unambiguous interpretation).
  */
 export function normalizeAtomCoords(frame: Frame): void {
@@ -97,7 +97,7 @@ export function normalizeAtomCoords(frame: Frame): void {
   const outZ = new Float64Array(n);
 
   if (allScaled) {
-    const box = frame.simbox;
+    const box = frame.box;
     if (!box) {
       throw new Error(
         `atoms use scaled coords (${source.x}/${source.y}/${source.z}) but the frame has no simulation box to un-scale with`,
@@ -117,8 +117,8 @@ export function normalizeAtomCoords(frame: Frame): void {
     const origin = copyAndFree(box.origin());
     const lengths = copyAndFree(box.lengths());
     const tilts = copyAndFree(box.tilts());
-    // NOTE: do NOT free `box` (the simbox getter result). Empirically, freeing
-    // a getBlock/simbox handle corrupts the frame's shared box data for later
+    // NOTE: do NOT free `box` (the box getter result). Empirically, freeing
+    // a getBlock/box handle corrupts the frame's shared box data for later
     // reads (the getter is not an independent copy). Only the WasmArray results
     // above are safe to free. See memory: project_molrs_handle_ownership.
     const ox = origin[0];

--- a/core/src/io/reader.ts
+++ b/core/src/io/reader.ts
@@ -249,7 +249,7 @@ export function loadBinaryTrajectory(
  * we would otherwise be picking a parser at random. Every UI-level
  * ingress point should catch that case and prompt the user.
  *
- * Column names, dtypes, and `simbox` come straight from molrs. Coordinate
+ * Column names, dtypes, and `box` come straight from molrs. Coordinate
  * columns are preserved as-read; downstream code may prefer `x/y/z` and fall
  * back to `xu/yu/zu`, but this loader does not synthesize missing columns.
  *

--- a/core/src/mode/measure.ts
+++ b/core/src/mode/measure.ts
@@ -1,5 +1,12 @@
 import type { AbstractMesh, PointerInfo } from "@babylonjs/core";
-import { Color3, MeshBuilder, Vector3 } from "@babylonjs/core";
+import {
+  Color3,
+  Mesh,
+  MeshBuilder,
+  StandardMaterial,
+  Vector3,
+} from "@babylonjs/core";
+import { WasmArray } from "@molcrafts/molrs";
 import type { MolvisApp as Molvis } from "../app";
 import { makeSelectionKey } from "../selection_manager";
 import { ContextMenuController } from "../ui/menus/controller";
@@ -18,9 +25,17 @@ interface MeasurementData {
 interface BufferItem {
   id: number; // Semantic Atom ID
   key: string; // Selection Key
-  position: Vector3; // Cached position
+  /** Render index into the atom impostor pool (`instanceData`). */
+  thinIndex: number;
+  position: Vector3; // Cached display position (matches impostor center)
   label: string;
 }
+
+/** World-space dash / gap lengths (Å). Fixed so short bonds stay readable. */
+const MEASURE_DASH_LEN = 0.18;
+const MEASURE_GAP_LEN = 0.12;
+/** Tube radius (Å) for the dashed connector — thick enough to read at typical zoom. */
+const MEASURE_LINE_RADIUS = 0.045;
 
 /**
  * Context menu controller for Measure mode.
@@ -158,10 +173,14 @@ class MeasureMode extends BaseMode {
     const thinIndex = hit.thinInstanceIndex;
     const meshId = hit.mesh.uniqueId;
 
+    // Prefer pick metadata (already resolved by the id-pass picker); fall
+    // back to a registry lookup only if the hit arrived without it.
     const meta =
-      thinIndex >= 0
-        ? this.world.sceneIndex.getMeta(meshId, thinIndex)
-        : this.world.sceneIndex.getMeta(meshId);
+      hit.metadata?.type === "atom"
+        ? hit.metadata
+        : thinIndex >= 0
+          ? this.world.sceneIndex.getMeta(meshId, thinIndex)
+          : this.world.sceneIndex.getMeta(meshId);
 
     if (meta?.type !== "atom") {
       return;
@@ -180,14 +199,11 @@ class MeasureMode extends BaseMode {
       this.clearAllMeasurements();
     }
 
-    // Robust Position Logic
-    let position: Vector3;
-    if (thinIndex < 0) {
-      position = hit.mesh.absolutePosition.clone();
-    } else {
-      // For thin instances, we assume they haven't moved individually
-      position = new Vector3(meta.position.x, meta.position.y, meta.position.z);
-    }
+    // Authoritative display position = impostor instanceData (what the
+    // shader draws). Meta.position is the same at frame load, but the GPU
+    // buffer is the single source of truth after position-only updates.
+    const position = this.resolveAtomPosition(thinIndex, meta.position);
+    if (!position) return;
 
     const label = meta.element;
     const selectionKey = makeSelectionKey(
@@ -198,6 +214,7 @@ class MeasureMode extends BaseMode {
     const item: BufferItem = {
       id: atomId,
       key: selectionKey,
+      thinIndex,
       position,
       label,
     };
@@ -213,6 +230,59 @@ class MeasureMode extends BaseMode {
 
     // Trigger Measurements
     this.processBuffer();
+  }
+
+  /**
+   * World-space center of the rendered atom impostor.
+   * Prefer the live `instanceData` buffer so the dashed line anchors on
+   * the same coordinates the shader uses (`centerWorld = instanceData.xyz`).
+   */
+  private resolveAtomPosition(
+    thinIndex: number,
+    fallback: { x: number; y: number; z: number },
+  ): Vector3 {
+    if (thinIndex >= 0) {
+      const atomState = this.world.sceneIndex.meshRegistry.getAtomState();
+      const data = atomState?.buffers.get("instanceData");
+      if (data) {
+        const o = thinIndex * data.stride;
+        if (o + 2 < data.data.length) {
+          return new Vector3(data.data[o], data.data[o + 1], data.data[o + 2]);
+        }
+      }
+    }
+    return new Vector3(fallback.x, fallback.y, fallback.z);
+  }
+
+  /**
+   * Displacement `b - a` honouring the frame's simulation box when present.
+   * Uses WASM `Box.delta(..., minimum_image = true)` so triclinic cells and
+   * partial-PBC flags match the bond renderer. Without a box (or on failure)
+   * falls back to the raw Euclidean vector between the display positions.
+   */
+  private measureDisplacement(a: Vector3, b: Vector3): Vector3 {
+    const box = this.app.system.frame.box;
+    if (!box) return b.subtract(a);
+
+    const aBuf = new Float64Array([a.x, a.y, a.z]);
+    const bBuf = new Float64Array([b.x, b.y, b.z]);
+    const shape = new Uint32Array([1, 3]);
+    const aArr = WasmArray.from(aBuf, shape);
+    const bArr = WasmArray.from(bBuf, shape);
+    try {
+      const delta = box.delta(aArr, bArr, true);
+      try {
+        const d = delta.toTypedArray();
+        return new Vector3(d[0], d[1], d[2]);
+      } finally {
+        delta.free();
+      }
+    } catch {
+      return b.subtract(a);
+    } finally {
+      aArr.free();
+      bArr.free();
+    }
   }
 
   private processBuffer() {
@@ -274,10 +344,15 @@ class MeasureMode extends BaseMode {
   // --- Measurement Creation ---
 
   private createDistanceMeasurement(start: BufferItem, end: BufferItem): void {
-    const distance = start.position.subtract(end.position).length();
+    // Measure along the minimum-image displacement when a simbox is present
+    // (matches bond rendering). The line is drawn from the displayed start
+    // atom to `start + delta`, which is the image of `end` used for the value.
+    const delta = this.measureDisplacement(start.position, end.position);
+    const distance = delta.length();
     const id = `measure_${Date.now()}_dist`;
 
-    const line = this.createMeasurementLine(start.position, end.position);
+    const lineEnd = start.position.add(delta);
+    const line = this.createMeasurementLine(start.position, lineEnd);
 
     const measurement: MeasurementData = {
       id,
@@ -295,8 +370,11 @@ class MeasureMode extends BaseMode {
     b: BufferItem,
     c: BufferItem,
   ): void {
-    const vBA = a.position.subtract(b.position).normalize();
-    const vBC = c.position.subtract(b.position).normalize();
+    // Vectors from the vertex, MI-aware so angles across periodic boundaries
+    // match the same convention as distance. Visuals are owned by the
+    // intervening distance measurements (A–B, B–C).
+    const vBA = this.measureDisplacement(b.position, a.position).normalize();
+    const vBC = this.measureDisplacement(b.position, c.position).normalize();
 
     const dot = Vector3.Dot(vBA, vBC);
     const angleRad = Math.acos(Math.max(-1, Math.min(1, dot)));
@@ -320,9 +398,10 @@ class MeasureMode extends BaseMode {
     c: BufferItem,
     d: BufferItem,
   ): void {
-    const b1 = b.position.subtract(a.position);
-    const b2 = c.position.subtract(b.position);
-    const b3 = d.position.subtract(c.position);
+    // Chain of MI displacements so each bond leg is the short image.
+    const b1 = this.measureDisplacement(a.position, b.position);
+    const b2 = this.measureDisplacement(b.position, c.position);
+    const b3 = this.measureDisplacement(c.position, d.position);
 
     const b2Norm = b2.length();
     if (b2Norm < 1e-6) return;
@@ -349,26 +428,53 @@ class MeasureMode extends BaseMode {
     this.measurements.set(id, measurement);
   }
 
-  // Use Dashed Lines
+  /**
+   * Build a dashed connector whose endpoints land exactly on `start` / `end`.
+   *
+   * Uses short tubes (not `CreateDashedLines`) so:
+   * - endpoints cover the full interval (no residual gap at the far end)
+   * - the stroke has real world-space thickness (LinesMesh is 1 px and hard to see)
+   */
   private createMeasurementLine(start: Vector3, end: Vector3): AbstractMesh {
-    const points = [start, end];
-    const line = MeshBuilder.CreateDashedLines(
-      "measurement_line",
-      {
-        points,
-        dashSize: 3,
-        gapSize: 1,
-        dashNb: 20,
-      },
-      this.world.scene,
+    const segments = buildDashedLineSegments(
+      start,
+      end,
+      MEASURE_DASH_LEN,
+      MEASURE_GAP_LEN,
     );
+    const scene = this.world.scene;
+    const root = new Mesh("measurement_line", scene);
+    root.isPickable = false;
+    root.alwaysSelectAsActiveMesh = true;
+    root.renderingGroupId = 1;
 
-    // Allow picking/color through standard material?
-    // CreateDashedLines returns LinesMesh which uses color property, not material.diffuseColor in the same way.
-    line.color = new Color3(1, 1, 0);
-    line.alpha = 0.8;
+    const mat = new StandardMaterial("measurement_line_mat", scene);
+    mat.emissiveColor = new Color3(1, 1, 0);
+    mat.disableLighting = true;
+    mat.alpha = 0.95;
+    // Parent owns the material; disposing root cleans children + mat.
+    root.material = mat;
 
-    return line;
+    for (let i = 0; i < segments.length; i++) {
+      const [a, b] = segments[i];
+      if (Vector3.DistanceSquared(a, b) < 1e-12) continue;
+      const tube = MeshBuilder.CreateTube(
+        `measurement_dash_${i}`,
+        {
+          path: [a, b],
+          radius: MEASURE_LINE_RADIUS,
+          tessellation: 6,
+          cap: Mesh.CAP_ALL,
+        },
+        scene,
+      );
+      tube.material = mat;
+      tube.isPickable = false;
+      tube.parent = root;
+      tube.renderingGroupId = 1;
+    }
+
+    return root;
   }
 
   private updateInfoPanel(): void {
@@ -468,6 +574,45 @@ class MeasureMode extends BaseMode {
       this.clearAllMeasurements();
     }
   }
+}
+
+/**
+ * Split `[start, end]` into solid dash segments of fixed world length.
+ * The final dash always reaches `end` so the visual anchors land exactly
+ * on the measured points (unlike Babylon's count-based CreateDashedLines).
+ */
+function buildDashedLineSegments(
+  start: Vector3,
+  end: Vector3,
+  dashLen: number,
+  gapLen: number,
+): Vector3[][] {
+  const dir = end.subtract(start);
+  const total = dir.length();
+  if (total < 1e-8) return [[start.clone(), end.clone()]];
+
+  const unit = dir.scale(1 / total);
+  const segments: Vector3[][] = [];
+  let cursor = 0;
+  while (cursor < total - 1e-8) {
+    const dashEnd = Math.min(cursor + dashLen, total);
+    segments.push([
+      start.add(unit.scale(cursor)),
+      start.add(unit.scale(dashEnd)),
+    ]);
+    if (dashEnd >= total - 1e-8) break;
+    cursor = dashEnd + gapLen;
+  }
+  // Guarantee the far endpoint is present even if a gap would have eaten it.
+  if (segments.length === 0) {
+    segments.push([start.clone(), end.clone()]);
+  } else {
+    const last = segments[segments.length - 1][1];
+    if (Vector3.DistanceSquared(last, end) > 1e-10) {
+      segments.push([last.clone(), end.clone()]);
+    }
+  }
+  return segments;
 }
 
 export { MeasureMode };

--- a/core/src/modifiers/AssignColorModifier.ts
+++ b/core/src/modifiers/AssignColorModifier.ts
@@ -111,8 +111,8 @@ export class AssignColorModifier extends BaseModifier {
     if (bonds) result.insertBlock("bonds", bonds);
 
     // Preserve box
-    const box = input.simbox;
-    if (box) result.simbox = box;
+    const box = input.box;
+    if (box) result.box = box;
 
     return result;
   }

--- a/core/src/modifiers/ColorByPropertyModifier.ts
+++ b/core/src/modifiers/ColorByPropertyModifier.ts
@@ -274,9 +274,9 @@ export class ColorByPropertyModifier extends BaseModifier {
       result.insertBlock("bonds", bonds);
     }
 
-    const box = input.simbox;
+    const box = input.box;
     if (box) {
-      result.simbox = box;
+      result.box = box;
     }
 
     return result;

--- a/core/src/modifiers/ComputeBondsModifier.ts
+++ b/core/src/modifiers/ComputeBondsModifier.ts
@@ -28,7 +28,7 @@ const FALLBACK_RADIUS = 0.77;
  * `DrawBondModifier` so the renderer draws the perceived topology.
  *
  * Neighbor search uses molrs `LinkedCell` (O(N) cell list, PBC-aware via
- * `frame.simbox`); we post-filter returned pairs by the per-pair threshold.
+ * `frame.box`); we post-filter returned pairs by the per-pair threshold.
  */
 export class ComputeBondsModifier extends BaseModifier {
   private _criterion: BondCriterion = "covalent";
@@ -215,8 +215,8 @@ export class ComputeBondsModifier extends BaseModifier {
       result.insertBlock("bonds", bonds);
     }
 
-    const box = input.simbox;
-    if (box) result.simbox = box;
+    const box = input.box;
+    if (box) result.box = box;
 
     return result;
   }

--- a/core/src/modifiers/DeleteSelectedModifier.ts
+++ b/core/src/modifiers/DeleteSelectedModifier.ts
@@ -152,8 +152,8 @@ export class DeleteSelectedModifier extends BaseModifier {
     result.insertBlock("atoms", newAtoms);
     if (newBonds) result.insertBlock("bonds", newBonds);
 
-    const box = input.simbox;
-    if (box) result.simbox = box;
+    const box = input.box;
+    if (box) result.box = box;
 
     return result;
   }

--- a/core/src/modifiers/HideHydrogensModifier.ts
+++ b/core/src/modifiers/HideHydrogensModifier.ts
@@ -118,8 +118,8 @@ export class HideHydrogensModifier extends BaseModifier {
     if (newBonds) result.insertBlock("bonds", newBonds);
 
     // Preserve box
-    const box = input.simbox;
-    if (box) result.simbox = box;
+    const box = input.box;
+    if (box) result.box = box;
 
     return result;
   }

--- a/core/src/modifiers/HideSelectionModifier.ts
+++ b/core/src/modifiers/HideSelectionModifier.ts
@@ -151,8 +151,8 @@ export class HideSelectionModifier extends BaseModifier {
     result.insertBlock("atoms", newAtoms);
     if (newBonds) result.insertBlock("bonds", newBonds);
 
-    const box = input.simbox;
-    if (box) result.simbox = box;
+    const box = input.box;
+    if (box) result.box = box;
 
     return result;
   }

--- a/core/src/modifiers/WrapPBCModifier.ts
+++ b/core/src/modifiers/WrapPBCModifier.ts
@@ -14,7 +14,7 @@ export class WrapPBCModifier extends BaseModifier {
   }
 
   apply(input: Frame, _context: PipelineContext): Frame {
-    const box = input.simbox;
+    const box = input.box;
     if (!box) {
       logger.warn("WrapPBC: Frame has no box, skipping");
       return input;
@@ -88,7 +88,7 @@ export class WrapPBCModifier extends BaseModifier {
         result.insertBlock("bonds", bonds);
       }
 
-      result.simbox = box;
+      result.box = box;
       return result;
     } finally {
       coordsArr.free();

--- a/core/src/pipeline/draw_box.ts
+++ b/core/src/pipeline/draw_box.ts
@@ -26,7 +26,7 @@ export class DrawBoxModifier extends BaseModifier {
   }
 
   matches(frame: Frame): boolean {
-    return this._manualBox !== null || frame.simbox !== undefined;
+    return this._manualBox !== null || frame.box !== undefined;
   }
 
   get thicknessScale(): number {
@@ -70,7 +70,7 @@ export class DrawBoxModifier extends BaseModifier {
       ctx.app.artist.drawBox(undefined);
       return input;
     }
-    const box = this.createManualBox() ?? input.simbox;
+    const box = this.createManualBox() ?? input.box;
     try {
       ctx.app.artist.drawBox(box, {
         thicknessScale: this._thicknessScale,

--- a/core/src/pipeline/draw_isosurface.ts
+++ b/core/src/pipeline/draw_isosurface.ts
@@ -1,6 +1,6 @@
 /**
  * `DrawIsosurfaceModifier` — auto-attaches when a frame carries a 3-D
- * `"grid"` Block and a simbox. Renders an isosurface of the requested
+ * `"grid"` Block and a box. Renders an isosurface of the requested
  * channel via the shared `IsosurfaceRenderer`. Mesh installation is a
  * pure side-effect (Draws capability); the frame is returned unchanged.
  *
@@ -33,8 +33,8 @@ export class DrawIsosurfaceModifier extends BaseModifier {
   }
 
   /**
-   * Auto-attach whenever the frame has a 3-D grid block and a simbox.
-   * Both are required: the simbox provides the world transform that
+   * Auto-attach whenever the frame has a 3-D grid block and a box.
+   * Both are required: the box provides the world transform that
    * marching cubes uses to place each voxel.
    */
   matches(frame: Frame): boolean {
@@ -42,7 +42,7 @@ export class DrawIsosurfaceModifier extends BaseModifier {
     if (!grid) return false;
     const shape = grid.shape();
     if (shape.length !== 3) return false;
-    return frame.simbox !== undefined;
+    return frame.box !== undefined;
   }
 
   /** Read-only view of the current style — UI binds to this. */

--- a/core/src/pipeline/draw_ribbon.ts
+++ b/core/src/pipeline/draw_ribbon.ts
@@ -304,7 +304,7 @@ export class DrawRibbonModifier extends BaseModifier {
       (a, b) => a.chainId.localeCompare(b.chainId) || a.resSeq - b.resSeq,
     );
 
-    splitChainsAtBreaks(rows, input.simbox);
+    splitChainsAtBreaks(rows, input.box);
     assignSecondaryStructure(rows);
     writeResidueRows(input, rows);
 

--- a/core/src/pipeline/modifier.ts
+++ b/core/src/pipeline/modifier.ts
@@ -77,7 +77,7 @@ export interface Modifier {
    * the pipeline.
    *
    * - Auto-attaching modifiers (Draw*, BackboneRibbon) override to return
-   *   true based on frame contents (e.g., `frame.simbox` defined).
+   *   true based on frame contents (e.g., `frame.box` defined).
    * - User-opt-in modifiers (Slice, WrapPBC, ExpressionSelect, ...)
    *   inherit the BaseModifier default of `false`.
    *

--- a/core/src/scene_sync.ts
+++ b/core/src/scene_sync.ts
@@ -5,7 +5,7 @@ import { logger } from "./utils/logger";
 export interface BuildFrameFromSceneOptions {
   /**
    * Source frame to carry the simulation box over from. The box is moved into
-   * the new frame via the `simbox` getter→setter (the proven, leak-free pattern
+   * the new frame via the `box` getter→setter (the proven, leak-free pattern
    * used by pipeline modifiers); the source frame keeps its own box.
    */
   sourceFrame?: Frame;
@@ -112,13 +112,13 @@ export function buildFrameFromScene(
     frame.insertBlock("bonds", bondBlock);
   }
 
-  // Preserve the simulation box. `sourceFrame.simbox` (getter) returns a copy;
+  // Preserve the simulation box. `sourceFrame.box` (getter) returns a copy;
   // assigning it (setter) MOVES it into the new frame and leaves the source's
   // own box intact — the same pattern pipeline modifiers use. This fixes the
   // long-standing box-loss on save.
-  const sourceBox = options.sourceFrame?.simbox;
+  const sourceBox = options.sourceFrame?.box;
   if (sourceBox) {
-    frame.simbox = sourceBox;
+    frame.box = sourceBox;
   }
 
   logger.info(

--- a/core/src/system/source_composition.ts
+++ b/core/src/system/source_composition.ts
@@ -27,7 +27,7 @@ export async function composeSources(
 
   const composedBlocks = new Map<string, Block>();
   let atomCount: number | null = null;
-  let simbox: Box | undefined;
+  let composedBox: Box | undefined;
 
   for (let i = 0; i < sources.length; i++) {
     const source = sources[i];
@@ -56,11 +56,11 @@ export async function composeSources(
         composedBlocks.set(name, cloneBlock(block));
       }
     }
-    const box = frame.simbox;
+    const box = frame.box;
     if (box !== undefined) {
-      simbox?.free();
+      composedBox?.free();
       try {
-        simbox = cloneBox(box);
+        composedBox = cloneBox(box);
       } finally {
         box.free();
       }
@@ -71,7 +71,7 @@ export async function composeSources(
   for (const [name, block] of composedBlocks) {
     result.insertBlock(name, block);
   }
-  if (simbox !== undefined) result.simbox = simbox;
+  if (composedBox !== undefined) result.box = composedBox;
 
   return result;
 }
@@ -134,7 +134,7 @@ export function extendFrames(frames: readonly Frame[]): Frame {
 
   const bonds = concatBonds(frames, counts);
   if (bonds) result.insertBlock("bonds", bonds);
-  copySimbox(result, frames[0]);
+  copyBox(result, frames[0]);
   return result;
 }
 
@@ -150,7 +150,7 @@ export async function extendSourcesToTrajectory(
     const sourceFrames = await resolveFrames(sources, frameIndex);
     const frame = extendFrames(sourceFrames);
     frames.push(frame);
-    boxes.push(frame.simbox);
+    boxes.push(frame.box);
   }
   return new Trajectory(frames, boxes);
 }
@@ -193,7 +193,7 @@ function projectSource(source: CompositionSource, frame: Frame): Frame {
     const block = frame.getBlock(name);
     if (block && block.nrows() > 0) result.insertBlock(name, cloneBlock(block));
   }
-  copySimbox(result, frame);
+  copyBox(result, frame);
   return result;
 }
 
@@ -208,11 +208,11 @@ function cloneBlock(source: Block): Block {
   return cloned;
 }
 
-function copySimbox(target: Frame, source: Frame): void {
-  const box = source.simbox;
+function copyBox(target: Frame, source: Frame): void {
+  const box = source.box;
   if (box === undefined) return;
   try {
-    target.simbox = cloneBox(box);
+    target.box = cloneBox(box);
   } finally {
     box.free();
   }

--- a/core/src/system/trajectory.ts
+++ b/core/src/system/trajectory.ts
@@ -192,8 +192,7 @@ export class Trajectory {
       return undefined;
     }
     return (
-      this._boxes[this._currentIndex] ??
-      this._getFrame(this._currentIndex)?.simbox
+      this._boxes[this._currentIndex] ?? this._getFrame(this._currentIndex)?.box
     );
   }
 
@@ -294,7 +293,7 @@ export class Trajectory {
    *   source / last-rendered frame) and are left untouched to avoid a
    *   use-after-free / double-free.
    * - Boxes are intentionally not freed here: their ownership flows into draw
-   *   commands and `currentBox` falls back to `frame.simbox`, so freeing them
+   *   commands and `currentBox` falls back to `frame.box`, so freeing them
    *   risks a double-free. They are released with their frame.
    *
    * Async (streaming) trajectories release their provider and the LRU cache

--- a/core/src/transport/trajectory_worker/frame_codec.ts
+++ b/core/src/transport/trajectory_worker/frame_codec.ts
@@ -39,13 +39,13 @@ export function rehydrateFrame(msg: FrameMessage): Frame {
     }
   }
 
-  if (msg.simbox) {
-    frame.simbox = new Box(
-      msg.simbox.h,
-      msg.simbox.origin,
-      msg.simbox.pbc[0],
-      msg.simbox.pbc[1],
-      msg.simbox.pbc[2],
+  if (msg.box) {
+    frame.box = new Box(
+      msg.box.h,
+      msg.box.origin,
+      msg.box.pbc[0],
+      msg.box.pbc[1],
+      msg.box.pbc[2],
     );
   }
 
@@ -53,7 +53,7 @@ export function rehydrateFrame(msg: FrameMessage): Frame {
   // Each `GridPayload` contributes one or more value columns whose
   // length is `Nx*Ny*Nz`; the block's `shape` carries the 3D
   // dimensions. Origin/cell/pbc on the GridPayload are dropped — the
-  // cloud renderer reads geometry from `frame.simbox`. CHGCAR / POSCAR
+  // cloud renderer reads geometry from `frame.box`. CHGCAR / POSCAR
   // / CUBE all share grid lattice with the simulation box, so this is
   // lossless in practice. If a future format needs an independent
   // voxel basis we'll surface it via Block meta later.

--- a/core/src/transport/trajectory_worker/index.ts
+++ b/core/src/transport/trajectory_worker/index.ts
@@ -1,6 +1,7 @@
 export { rehydrateFrame } from "./frame_codec";
 export type {
   BlockPayload,
+  BoxPayload,
   CancelRequest,
   CloseRequest,
   ColumnPayload,
@@ -13,7 +14,6 @@ export type {
   LoadFrameRequest,
   OpenError,
   OpenRequest,
-  SimboxPayload,
   SourceHandle,
   WorkerRequest,
   WorkerResponse,

--- a/core/src/transport/trajectory_worker/protocol.ts
+++ b/core/src/transport/trajectory_worker/protocol.ts
@@ -63,7 +63,7 @@ export interface BlockPayload {
   columns: ColumnPayload[];
 }
 
-export interface SimboxPayload {
+export interface BoxPayload {
   /** Column-major 3×3 lattice matrix, length 9. */
   h: Float64Array;
   /** Cartesian origin in Å, length 3. */
@@ -186,7 +186,7 @@ export interface FrameMessage {
   requestId: number;
   frameId: number;
   blocks: BlockPayload[];
-  simbox: SimboxPayload | null;
+  box: BoxPayload | null;
   grids: GridPayload[];
 }
 
@@ -240,9 +240,9 @@ export function frameMessageTransferList(msg: FrameMessage): Transferable[] {
       if (col.dtype !== "string") out.push(col.data.buffer);
     }
   }
-  if (msg.simbox) {
-    out.push(msg.simbox.h.buffer);
-    out.push(msg.simbox.origin.buffer);
+  if (msg.box) {
+    out.push(msg.box.h.buffer);
+    out.push(msg.box.origin.buffer);
   }
   for (const grid of msg.grids) {
     out.push(grid.shape.buffer);

--- a/core/src/transport/trajectory_worker/worker.ts
+++ b/core/src/transport/trajectory_worker/worker.ts
@@ -36,6 +36,7 @@ import { OPFSSyncRangeSource } from "../../io/sources/opfs_sync_range_source";
 import type { TrajectorySource } from "../../io/sources/trajectory_source";
 import type {
   BlockPayload,
+  BoxPayload,
   CancelRequest,
   CloseRequest,
   ColumnPayload,
@@ -48,7 +49,6 @@ import type {
   LoadFrameRequest,
   OpenError,
   OpenRequest,
-  SimboxPayload,
   WorkerRequest,
 } from "./protocol";
 import { frameMessageTransferList } from "./protocol";
@@ -331,7 +331,7 @@ async function handleLoadFrame(req: LoadFrameRequest): Promise<void> {
   // also detaches the ArrayBuffer view, so we re-derive views as we
   // go, never cache them across calls.
   const blocks = readBlocks(state.stream);
-  const simbox = readSimbox(state.stream);
+  const box = readBox(state.stream);
   const grids = readGrids(state.stream);
 
   state.stream.releaseFrame();
@@ -341,7 +341,7 @@ async function handleLoadFrame(req: LoadFrameRequest): Promise<void> {
     requestId: req.requestId,
     frameId: req.frameId,
     blocks,
-    simbox,
+    box,
     grids,
   };
   postWithTransfer(msg, frameMessageTransferList(msg));
@@ -407,11 +407,11 @@ function readBlocks(s: WasmTrajStream): BlockPayload[] {
   return out;
 }
 
-function readSimbox(s: WasmTrajStream): SimboxPayload | null {
-  const h = s.simboxH();
-  const origin = s.simboxOrigin();
+function readBox(s: WasmTrajStream): BoxPayload | null {
+  const h = s.boxH();
+  const origin = s.boxOrigin();
   if (!h || !origin) return null;
-  const pbcRaw = s.simboxPbc(); // Vec<u8>(3) per molrs-wasm impl
+  const pbcRaw = s.boxPbc(); // Vec<u8>(3) per molrs-wasm impl
   const pbc = pbcToTuple(pbcRaw);
   return {
     h: new Float64Array(h),
@@ -424,7 +424,7 @@ function readGrids(_s: WasmTrajStream): GridPayload[] {
   // molrs >= 0.0.16 dropped the dedicated grid-streaming accessors
   // (gridCount/gridShape/gridArrayPtrF64/...) in favour of the unified
   // "grids are blocks" model. The incremental streaming API
-  // (WasmLammpsDumpStream et al.) exposes blocks + columns + simbox but no
+  // (WasmLammpsDumpStream et al.) exposes blocks + columns + box but no
   // per-block shape, so a streamed volumetric "grid" block cannot be
   // reconstructed with geometry here. Streamed trajectories therefore carry
   // no volumetric grids; full-file loads still surface grids via the

--- a/core/src/world.ts
+++ b/core/src/world.ts
@@ -251,8 +251,8 @@ export class World {
   ): { points: Float64Array; radii: Float64Array } | null {
     const atoms = this.sceneIndex.getBoundsData();
     const corners =
-      frameBox && this._app.frame?.simbox
-        ? copyAndFreeF64(this._app.frame.simbox.get_corners())
+      frameBox && this._app.frame?.box
+        ? copyAndFreeF64(this._app.frame.box.get_corners())
         : null;
 
     if (!corners || corners.length < 24) {

--- a/core/tests/analysis_catalog.test.ts
+++ b/core/tests/analysis_catalog.test.ts
@@ -37,7 +37,7 @@ function positionsOnlyFrame(): Frame {
   block.setColStr("element", ["C", "C", "O"]);
   const frame = new Frame();
   frame.insertBlock("atoms", block);
-  frame.simbox = Box.cube(10, new Float64Array([0, 0, 0]), true, true, true);
+  frame.box = Box.cube(10, new Float64Array([0, 0, 0]), true, true, true);
   return frame;
 }
 

--- a/core/tests/auto_modifiers.test.ts
+++ b/core/tests/auto_modifiers.test.ts
@@ -219,7 +219,7 @@ describe("DrawRibbonModifier.apply", () => {
         chain_id: ["A", "A", "A"],
       },
     );
-    frame.simbox = Box.cube(50, new Float64Array([0, 0, 0]), true, true, true);
+    frame.box = Box.cube(50, new Float64Array([0, 0, 0]), true, true, true);
     const ctx = testContext();
     const out = new DrawRibbonModifier().apply(frame, ctx);
     const residues = out.getBlock("residues");
@@ -242,7 +242,7 @@ describe("DrawRibbonModifier.apply", () => {
         chain_id: ["A", "A", "A", "A"],
       },
     );
-    frame.simbox = Box.cube(50, new Float64Array([0, 0, 0]), true, true, true);
+    frame.box = Box.cube(50, new Float64Array([0, 0, 0]), true, true, true);
     const ctx = testContext();
     const out = new DrawRibbonModifier().apply(frame, ctx);
     const residues = out.getBlock("residues");

--- a/core/tests/axis_helper.test.ts
+++ b/core/tests/axis_helper.test.ts
@@ -1,4 +1,10 @@
-import { ArcRotateCamera, NullEngine, Scene, Vector3 } from "@babylonjs/core";
+import {
+  ArcRotateCamera,
+  NullEngine,
+  Quaternion,
+  Scene,
+  Vector3,
+} from "@babylonjs/core";
 import { describe, expect, it } from "@rstest/core";
 import { AxisHelper, axisHelperViewport } from "../src/axis_helper";
 
@@ -15,7 +21,7 @@ describe("AxisHelper", () => {
     expect(doubled.y * 1600).toBeCloseTo(viewport.y * 800 * 2, 6);
   });
 
-  it("rotates only the Z label 180 degrees around its local Z axis", () => {
+  it("uses manual orientation with RH un-mirror (scaling.x = -1), no billboard", () => {
     const engine = new NullEngine({ renderWidth: 1200, renderHeight: 800 });
     const scene = new Scene(engine);
     const camera = new ArcRotateCamera(
@@ -26,16 +32,83 @@ describe("AxisHelper", () => {
       Vector3.Zero(),
       scene,
     );
+    camera.upVector = new Vector3(0, 0, 1);
     const helper = new AxisHelper(engine, camera);
 
     try {
       const gizmoScene = engine.scenes.find((candidate) => candidate !== scene);
-      expect(gizmoScene?.getMeshByName("axisLabelX")?.rotation.z).toBe(0);
-      expect(gizmoScene?.getMeshByName("axisLabelY")?.rotation.z).toBe(0);
-      expect(gizmoScene?.getMeshByName("axisLabelZ")?.rotation.z).toBeCloseTo(
-        Math.PI,
-        6,
-      );
+      for (const name of ["axisLabelX", "axisLabelY", "axisLabelZ"]) {
+        const mesh = gizmoScene?.getMeshByName(name);
+        expect(mesh).toBeTruthy();
+        // BILLBOARDMODE_NONE === 0 — manual orientation avoids the Z-up singularity.
+        expect(mesh?.billboardMode ?? 0).toBe(0);
+        // RH front-face view mirrors local +X; flip so Z diagonal is \ not /.
+        expect(mesh?.scaling.x).toBeCloseTo(-1, 6);
+        expect(mesh?.scaling.y).toBeCloseTo(1, 6);
+        expect(mesh?.rotationQuaternion).toBeTruthy();
+      }
+    } finally {
+      helper.dispose();
+      scene.dispose();
+      engine.dispose();
+    }
+  });
+
+  it("places axis tips along +X, +Y, +Z (right-handed Z-up)", () => {
+    const engine = new NullEngine({ renderWidth: 1200, renderHeight: 800 });
+    const scene = new Scene(engine);
+    scene.useRightHandedSystem = true;
+    const camera = new ArcRotateCamera(
+      "camera",
+      Math.PI / 4,
+      Math.acos(1 / Math.sqrt(3)),
+      10,
+      Vector3.Zero(),
+      scene,
+    );
+    camera.upVector = new Vector3(0, 0, 1);
+    const helper = new AxisHelper(engine, camera);
+
+    try {
+      const gizmoScene = engine.scenes.find((candidate) => candidate !== scene);
+      expect(gizmoScene).toBeTruthy();
+
+      // Labels sit just past the arrow tip along each world axis.
+      // AxisViewer size = 2.5, label offset = size + 0.35 = 2.85.
+      const tip = 2.85;
+      const labelX = gizmoScene!.getMeshByName("axisLabelX")!;
+      const labelY = gizmoScene!.getMeshByName("axisLabelY")!;
+      const labelZ = gizmoScene!.getMeshByName("axisLabelZ")!;
+
+      expect(labelX.position.x).toBeCloseTo(tip, 5);
+      expect(labelX.position.y).toBeCloseTo(0, 5);
+      expect(labelX.position.z).toBeCloseTo(0, 5);
+
+      expect(labelY.position.x).toBeCloseTo(0, 5);
+      expect(labelY.position.y).toBeCloseTo(tip, 5);
+      expect(labelY.position.z).toBeCloseTo(0, 5);
+
+      // Z must point to +Z — this is the invariant that kept regressing.
+      expect(labelZ.position.x).toBeCloseTo(0, 5);
+      expect(labelZ.position.y).toBeCloseTo(0, 5);
+      expect(labelZ.position.z).toBeCloseTo(tip, 5);
+
+      // Pivot quaternions must map local +Y onto each world axis.
+      for (const [name, expected] of [
+        ["pivotX", new Vector3(1, 0, 0)],
+        ["pivotY", new Vector3(0, 1, 0)],
+        ["pivotZ", new Vector3(0, 0, 1)],
+      ] as const) {
+        const pivot = gizmoScene!.getMeshByName(name)!;
+        expect(pivot).toBeTruthy();
+        const q =
+          pivot.rotationQuaternion ??
+          Quaternion.FromEulerVector(pivot.rotation);
+        const worldDir = new Vector3(0, 1, 0).applyRotationQuaternion(q);
+        expect(worldDir.x).toBeCloseTo(expected.x, 5);
+        expect(worldDir.y).toBeCloseTo(expected.y, 5);
+        expect(worldDir.z).toBeCloseTo(expected.z, 5);
+      }
     } finally {
       helper.dispose();
       scene.dispose();
@@ -57,6 +130,7 @@ describe("AxisHelper", () => {
       Vector3.Zero(),
       scene,
     );
+    camera.upVector = new Vector3(0, 0, 1);
     const helper = new AxisHelper(engine, camera);
 
     try {

--- a/core/tests/build_frame_from_scene.test.ts
+++ b/core/tests/build_frame_from_scene.test.ts
@@ -56,7 +56,7 @@ describe("buildFrameFromScene", () => {
 
   it("preserves the simulation box from the source frame", () => {
     const sourceFrame = new Frame();
-    sourceFrame.simbox = Box.cube(
+    sourceFrame.box = Box.cube(
       10,
       new Float64Array([0, 0, 0]),
       true,
@@ -64,14 +64,14 @@ describe("buildFrameFromScene", () => {
       true,
     );
     const frame = buildFrameFromScene(sceneWith3Atoms(), { sourceFrame });
-    expect(frame.simbox).toBeTruthy();
+    expect(frame.box).toBeTruthy();
     // The source frame keeps its own box (getter→setter move pattern).
-    expect(sourceFrame.simbox).toBeTruthy();
+    expect(sourceFrame.box).toBeTruthy();
   });
 
   it("does NOT mutate/clear the source frame (immutability)", () => {
     const sourceFrame = new Frame();
-    sourceFrame.simbox = Box.cube(
+    sourceFrame.box = Box.cube(
       5,
       new Float64Array([0, 0, 0]),
       true,
@@ -80,7 +80,7 @@ describe("buildFrameFromScene", () => {
     );
     buildFrameFromScene(sceneWith3Atoms(), { sourceFrame });
     // Source frame must remain usable and box intact after the build.
-    expect(() => sourceFrame.simbox).not.toThrow();
-    expect(sourceFrame.simbox).toBeTruthy();
+    expect(() => sourceFrame.box).not.toThrow();
+    expect(sourceFrame.box).toBeTruthy();
   });
 });

--- a/core/tests/camera_fit.test.ts
+++ b/core/tests/camera_fit.test.ts
@@ -1,6 +1,8 @@
+import { ArcRotateCamera, NullEngine, Scene, Vector3 } from "@babylonjs/core";
 import { describe, expect, it } from "@rstest/core";
 import {
   aabbToObb,
+  anglesFromForward,
   FIT_MIN_DISTANCE,
   FIT_PADDING,
   fitBoxToView,
@@ -64,6 +66,53 @@ describe("fitBoxToView — per-axis, radius-aware, auto-view", () => {
       max: { x: 0.001, y: 0.001, z: 0.001 },
     });
     expect(fitBoxToView(tiny, FOV, 1).radius).toBe(FIT_MIN_DISTANCE);
+  });
+
+  it("viewBasis dir matches Babylon Z-up ArcRotateCamera position (Y sign)", () => {
+    // Regression: the textbook Y-up formula used +sinβ·sinα for Y, but Babylon
+    // with upVector=(0,0,1) places the camera at −sinβ·sinα. Wrong sign sent
+    // auto-view to the opposite hemisphere → structures looked Z-flipped.
+    const engine = new NullEngine({ renderWidth: 200, renderHeight: 200 });
+    const scene = new Scene(engine);
+    scene.useRightHandedSystem = true;
+    try {
+      for (const [alpha, beta] of [
+        [Math.PI / 4, Math.acos(1 / Math.sqrt(3))],
+        [-Math.PI / 4, Math.PI / 3],
+        [Math.PI / 2, Math.PI / 2],
+        [-Math.PI / 2, Math.PI / 2],
+        [0, Math.PI / 2],
+      ] as const) {
+        const camera = new ArcRotateCamera(
+          "c",
+          alpha,
+          beta,
+          10,
+          Vector3.Zero(),
+          scene,
+        );
+        camera.upVector = new Vector3(0, 0, 1);
+        camera.getViewMatrix();
+        const basis = viewBasis(alpha, beta);
+        // Camera looks along forward; position is opposite forward * radius.
+        expect(camera.position.x).toBeCloseTo(-basis.forward[0] * 10, 5);
+        expect(camera.position.y).toBeCloseTo(-basis.forward[1] * 10, 5);
+        expect(camera.position.z).toBeCloseTo(-basis.forward[2] * 10, 5);
+
+        // Round-trip through anglesFromForward.
+        const back = anglesFromForward(basis.forward);
+        expect(back.beta).toBeCloseTo(beta, 5);
+        // alpha is defined mod 2π; compare unit vectors in the XY plane.
+        const a0 = [Math.cos(alpha), Math.sin(alpha)];
+        const a1 = [Math.cos(back.alpha), Math.sin(back.alpha)];
+        expect(a0[0]).toBeCloseTo(a1[0], 5);
+        expect(a0[1]).toBeCloseTo(a1[1], 5);
+        camera.dispose();
+      }
+    } finally {
+      scene.dispose();
+      engine.dispose();
+    }
   });
 
   it("never clips: every corner of a tilted box stays within the framed view (ac-005)", () => {

--- a/core/tests/cube_chgcar_load.test.ts
+++ b/core/tests/cube_chgcar_load.test.ts
@@ -75,7 +75,7 @@ function syntheticGridFrame(nx: number, ny: number, nz: number): Frame {
     false,
     false,
   );
-  frame.simbox = box;
+  frame.box = box;
 
   // Trivial atoms block — present so DrawAtomModifier doesn't reject
   // the frame in pipeline tests, but content is not load-bearing.
@@ -132,7 +132,7 @@ describe("loadTextTrajectory cube path", () => {
       expect(grid).toBeDefined();
       const shape = grid ? Array.from(grid.shape()) : [];
       expect(shape).toEqual([1, 1, 5]);
-      expect(frame?.simbox).toBeDefined();
+      expect(frame?.box).toBeDefined();
 
       const atoms = frame?.getBlock("atoms");
       expect(atoms?.nrows()).toBe(2);

--- a/core/tests/gromacs_vasp_load.test.ts
+++ b/core/tests/gromacs_vasp_load.test.ts
@@ -115,7 +115,7 @@ describe("loadTextTrajectory GROMACS / VASP path", () => {
       const x = atoms?.copyColF("x");
       // HW1 sits at x = 0.100 nm -> 1.0 angstrom after conversion.
       expect(x?.[1]).toBeCloseTo(1.0, 6);
-      expect(frame?.simbox).toBeDefined();
+      expect(frame?.box).toBeDefined();
     } finally {
       bundle.dispose();
     }
@@ -147,7 +147,7 @@ describe("loadTextTrajectory GROMACS / VASP path", () => {
       const x = atoms?.copyColF("x");
       // (0.5,0.5,0.5) fractional in a 2.5 angstrom cube -> 1.25 angstrom.
       expect(x?.[1]).toBeCloseTo(1.25, 6);
-      expect(frame?.simbox).toBeDefined();
+      expect(frame?.box).toBeDefined();
     } finally {
       bundle.dispose();
     }

--- a/core/tests/lazy_reader.test.ts
+++ b/core/tests/lazy_reader.test.ts
@@ -13,6 +13,21 @@ H 2.0 0.0 0.0
 He 3.0 0.0 0.0
 `;
 
+// Blank lines between frames / trailing blanks are common from ASE and
+// some MD exporters. molrs XYZReader::len() used to throw
+// "XYZ len error: invalid atom count:" on these files.
+const XYZ_TRAJECTORY_WITH_BLANKS = `2
+frame 0
+H 0.0 0.0 0.0
+He 1.0 0.0 0.0
+
+2
+frame 1
+H 2.0 0.0 0.0
+He 3.0 0.0 0.0
+
+`;
+
 // Extended-XYZ declares its element column via the `Properties=` header. With
 // `species:S:1` the molrs reader emits a `species` column, not `element`; the
 // reader must normalize it so per-element coloring / bonds / RDF still work.
@@ -48,6 +63,24 @@ describe("loadTextTrajectory", () => {
       expect(firstCoords?.x[1]).toBe(1);
       expect(secondCoords?.x[0]).toBe(2);
       expect(secondCoords?.x[1]).toBe(3);
+    } finally {
+      bundle.dispose();
+    }
+  });
+
+  it("opens multi-frame xyz with inter-frame and trailing blank lines", () => {
+    const bundle = loadTextTrajectory(XYZ_TRAJECTORY_WITH_BLANKS, "traj.xyz");
+
+    try {
+      expect(bundle.trajectory.length).toBe(2);
+      const firstCoords = viewAtomCoords(
+        bundle.trajectory.get(0)!.getBlock("atoms")!,
+      );
+      const secondCoords = viewAtomCoords(
+        bundle.trajectory.get(1)!.getBlock("atoms")!,
+      );
+      expect(firstCoords?.x[0]).toBe(0);
+      expect(secondCoords?.x[0]).toBe(2);
     } finally {
       bundle.dispose();
     }

--- a/core/tests/rdf.test.ts
+++ b/core/tests/rdf.test.ts
@@ -23,7 +23,7 @@ function makePeriodicFrame(
 ): Frame {
   const frame = makeFrame(positions);
   const box = Box.cube(boxSize, new Float64Array([0, 0, 0]), true, true, true);
-  frame.simbox = box;
+  frame.box = box;
   return frame;
 }
 

--- a/core/tests/source_composition.test.ts
+++ b/core/tests/source_composition.test.ts
@@ -147,7 +147,7 @@ describe("loader-time extend", () => {
 
   it("copies source WASM handles instead of consuming them", async () => {
     const a = atoms(["C"], 0);
-    a.simbox = Box.cube(10, new Float64Array([0, 0, 0]), true, true, true);
+    a.box = Box.cube(10, new Float64Array([0, 0, 0]), true, true, true);
     const b = atoms(["O"], 5);
 
     const projected = await composeSources(
@@ -160,9 +160,9 @@ describe("loader-time extend", () => {
     expect(projected.getBlock("atoms")?.nrows()).toBe(1);
     expect(extended.getBlock("atoms")?.nrows()).toBe(2);
 
-    const sourceBox = a.simbox;
-    const projectedBox = projected.simbox;
-    const extendedBox = extended.simbox;
+    const sourceBox = a.box;
+    const projectedBox = projected.box;
+    const extendedBox = extended.box;
     try {
       expect(sourceBox?.volume()).toBe(1000);
       expect(projectedBox?.volume()).toBe(1000);

--- a/core/tests/test_wasm.ts
+++ b/core/tests/test_wasm.ts
@@ -141,13 +141,13 @@ describe("WASM Frame", () => {
   it("accepts and detaches a simbox", () => {
     const frame = new Frame();
     const box = Box.cube(5, new Float64Array([0, 0, 0]), true, true, true);
-    frame.simbox = box;
-    const roundTrip = frame.simbox;
+    frame.box = box;
+    const roundTrip = frame.box;
     expect(roundTrip).toBeDefined();
     expect(roundTrip?.volume()).toBeCloseTo(125, 10);
 
-    frame.simbox = null;
-    expect(frame.simbox).toBeUndefined();
+    frame.box = null;
+    expect(frame.box).toBeUndefined();
   });
 
   it("manages grid blocks with structural shape (insert / get / remove / names)", () => {
@@ -336,7 +336,7 @@ describe("WASM Readers", () => {
     const frame = reader.read(0);
     expect(frame).toBeDefined();
     expect(frame?.getBlock("atoms")?.nrows()).toBe(2);
-    expect(frame?.simbox).toBeDefined();
+    expect(frame?.box).toBeDefined();
     reader.free();
   });
 
@@ -395,7 +395,7 @@ describe("WASM Readers", () => {
     expect(resSeq?.[1]).toBe(1);
     expect(resSeq?.[2]).toBe(0);
 
-    expect(frame?.simbox).toBeDefined();
+    expect(frame?.box).toBeDefined();
     reader.free();
   });
 });
@@ -410,7 +410,7 @@ describe("WASM Analysis", () => {
     atoms.setColF("y", new Float64Array([0, 0, 0, 0]));
     atoms.setColF("z", new Float64Array([0, 0, 0, 0]));
     atoms.setColStr("element", ["Ar", "Ar", "Ar", "Ar"]);
-    frame.simbox = Box.cube(10, new Float64Array([0, 0, 0]), true, true, true);
+    frame.box = Box.cube(10, new Float64Array([0, 0, 0]), true, true, true);
 
     const lc = new LinkedCell(1.5);
     const nlist = lc.build(frame);
@@ -434,7 +434,7 @@ describe("WASM Analysis", () => {
       "element",
       positions.map(() => "Ar"),
     );
-    frame.simbox = Box.cube(10, new Float64Array([0, 0, 0]), true, true, true);
+    frame.box = Box.cube(10, new Float64Array([0, 0, 0]), true, true, true);
 
     const lc = new LinkedCell(5);
     const nlist = lc.build(frame);

--- a/core/tests/theme_example_xyz.test.ts
+++ b/core/tests/theme_example_xyz.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "@rstest/core";
+import { normalizeInlineSource } from "../src/element";
+import { loadTextTrajectory } from "../src/io/reader";
+import "./setup_wasm";
+
+// Pretty-printed template textContent (leading newline + trailing indent)
+// used to surface as "XYZ len error: invalid atom count:" on molrs ≤0.8.2.
+const PRETTY_TEMPLATE = `\n3\nname=water Connct="[0,1,0,2]"\nO  0.0000  0.0000  0.0000\nH  0.9572  0.0000  0.0000\nH -0.2390  0.9266  0.0000\n      `;
+
+describe("theme example xyz", () => {
+  it("normalizeInlineSource strips pretty-print blanks", () => {
+    const cleaned = normalizeInlineSource(PRETTY_TEMPLATE);
+    expect(cleaned.startsWith("3\n")).toBe(true);
+    expect(cleaned.endsWith("0.0000")).toBe(true);
+    expect(cleaned).not.toMatch(/^\s/);
+    expect(cleaned).not.toMatch(/\s$/);
+  });
+
+  it("loads after normalize (docs template path)", () => {
+    const bundle = loadTextTrajectory(
+      normalizeInlineSource(PRETTY_TEMPLATE),
+      "water.xyz",
+    );
+    try {
+      expect(bundle.trajectory.length).toBe(1);
+      expect(bundle.trajectory.get(0)?.getBlock("atoms")?.nrows()).toBe(3);
+    } finally {
+      bundle.dispose();
+    }
+  });
+});

--- a/core/tests/trajectory_runtime.test.ts
+++ b/core/tests/trajectory_runtime.test.ts
@@ -158,7 +158,7 @@ describe("TrajectoryRuntime", () => {
             ],
           },
         ],
-        simbox: null,
+        box: null,
         grids: [],
       };
       fake.emit(frame);

--- a/core/tests/trajectory_worker_frame_codec.test.ts
+++ b/core/tests/trajectory_worker_frame_codec.test.ts
@@ -11,7 +11,7 @@ function emptyMessage(): FrameMessage {
     requestId: 1,
     frameId: 0,
     blocks: [],
-    simbox: null,
+    box: null,
     grids: [],
   };
 }
@@ -32,7 +32,7 @@ describe("rehydrateFrame", () => {
   it("builds an empty Frame from an empty message", () => {
     const frame = rehydrateFrame(emptyMessage());
     expect(frame.getBlock("atoms")).toBeUndefined();
-    expect(frame.simbox).toBeUndefined();
+    expect(frame.box).toBeUndefined();
     expect(frame.getBlock("grid")).toBeUndefined();
   });
 
@@ -68,16 +68,16 @@ describe("rehydrateFrame", () => {
     expect(frame.getBlock("bonds")?.nrows()).toBe(2);
   });
 
-  it("reattaches a triclinic simbox via Box(h, origin, pbc)", () => {
+  it("reattaches a triclinic box via Box(h, origin, pbc)", () => {
     const msg = emptyMessage();
-    msg.simbox = {
+    msg.box = {
       // 10 Å cube column-major
       h: new Float64Array([10, 0, 0, 0, 10, 0, 0, 0, 10]),
       origin: new Float64Array([0, 0, 0]),
       pbc: [true, true, false],
     };
     const frame = rehydrateFrame(msg);
-    expect(frame.simbox).toBeDefined();
+    expect(frame.box).toBeDefined();
   });
 
   it("reattaches a volumetric grid as a 'grid' block", () => {

--- a/core/tests/world_reset_camera.test.ts
+++ b/core/tests/world_reset_camera.test.ts
@@ -24,7 +24,7 @@ function makeAtomFrame(
   atoms.setColF("z", new Float64Array(coords.map((c) => c[2])));
   atoms.setColStr("element", elements);
   frame.insertBlock("atoms", atoms);
-  if (box) frame.simbox = box;
+  if (box) frame.box = box;
   return frame;
 }
 

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -245,7 +245,7 @@ atoms.viewColF("x");        // Float64Array — view into WASM memory
 atoms.copyColF("x");        // Float64Array — owned copy
 atoms.setColStr("element", ["C", "O", "H"]);
 
-frame.simbox;               // Box | undefined
+frame.box;               // Box | undefined
 frame.gridNames();          // string[] of volumetric field names
 frame.getGrid("density");   // Grid | undefined
 

--- a/docs/interfaces/web/install.md
+++ b/docs/interfaces/web/install.md
@@ -34,7 +34,7 @@ npm (jsDelivr):
 ```html
 <script
   type="module"
-  src="https://cdn.jsdelivr.net/npm/@molcrafts/molvis-core@0.1.0/dist/elements.js"
+  src="https://cdn.jsdelivr.net/npm/@molcrafts/molvis-core@0.1.1/dist/elements.js"
 ></script>
 ```
 

--- a/docs/specs/cube-chgcar-isosurface.md
+++ b/docs/specs/cube-chgcar-isosurface.md
@@ -107,10 +107,10 @@ already-reversible pipeline-edit commands.
 | Name | `DrawIsosurfaceModifier` |
 | File | `core/src/pipeline/draw_isosurface.ts` |
 | Category | Capability `Draws` (parallels `DrawAtomModifier` / `DrawBoxModifier`) |
-| Input | `frame.getBlock("grid")` (column `density` for cube; `total` and `diff` for CHGCAR), `frame.simbox` (for `cell` + `origin`) |
+| Input | `frame.getBlock("grid")` (column `density` for cube; `total` and `diff` for CHGCAR), `frame.box` (for `cell` + `origin`) |
 | Output | Frame returned unchanged (this is a side-effect Draw modifier — same as `DrawAtomModifier`); BabylonJS isosurface mesh installed via `artist.drawIsosurface(...)` |
-| `matches(frame)` | `frame.getBlock("grid") !== undefined && grid.shape().length === 3 && frame.simbox !== undefined` |
-| Pattern reference | Analogous to `DrawBoxModifier` in `core/src/pipeline/draw_box.ts` (auto-attaches on `frame.simbox`, calls `artist.drawBox(...)`) |
+| `matches(frame)` | `frame.getBlock("grid") !== undefined && grid.shape().length === 3 && frame.box !== undefined` |
+| Pattern reference | Analogous to `DrawBoxModifier` in `core/src/pipeline/draw_box.ts` (auto-attaches on `frame.box`, calls `artist.drawBox(...)`) |
 
 ### Mode Changes
 **No mode changes.** Isosurface is purely a render layer. View mode's
@@ -240,7 +240,7 @@ class IsosurfaceRenderer {
     const [nx, ny, nz] = grid.shape() as Uint32Array;
 
     // 2. Pull cell from simbox (column-major 3×3 + origin).
-    const box = frame.simbox!;
+    const box = frame.box!;
     const cell   = copyAndFree(box.h_matrix());
     const origin = copyAndFree(box.origin());
 
@@ -454,7 +454,7 @@ Ordered by dependency:
 - [ ] **Channel switch (Li_spin)**: switch channel from `total` to
   `diff`; assert mesh is re-extracted from the second column.
 - [ ] **Box memory hygiene**: after disposing the trajectory,
-  `frame.simbox` and the grid block are freed (no WASM leak — checked
+  `frame.box` and the grid block are freed (no WASM leak — checked
   via `WasmArray.activeCount()` if available, otherwise a
   `before/after` assertion on `wasm.memory.buffer.byteLength` growing
   bounded).

--- a/docs/specs/streaming-trajectory.md
+++ b/docs/specs/streaming-trajectory.md
@@ -348,9 +348,9 @@ declare class WasmLammpsDumpStream {
     columnStrings(blockIdx: number, colIdx: number): string[];
 
     /** Box: returns null if the frame has no simulation box. */
-    simboxH(): Float64Array | null;       // length 9, owned (copy)
-    simboxOrigin(): Float64Array | null;  // length 3, owned (copy)
-    simboxPbc(): [boolean, boolean, boolean] | null;
+    boxH(): Float64Array | null;       // length 9, owned (copy)
+    boxOrigin(): Float64Array | null;  // length 3, owned (copy)
+    boxPbc(): [boolean, boolean, boolean] | null;
 
     /** Volumetric grids. */
     gridCount(): number;
@@ -460,7 +460,7 @@ export interface FrameMessage {
     requestId: number;
     frameId: number;
     blocks: BlockPayload[];
-    simbox: SimboxPayload | null;
+    box: BoxPayload | null;
     grids: GridPayload[];
 }
 
@@ -493,7 +493,7 @@ export type ColumnPayload =
     | { name: string; dtype: "i32"; data: Int32Array }
     | { name: string; dtype: "string"; data: string[] };
 
-export interface SimboxPayload {
+export interface BoxPayload {
     h: Float64Array;        // length 9
     origin: Float64Array;   // length 3
     pbc: [boolean, boolean, boolean];
@@ -597,13 +597,13 @@ export function rehydrateFrame(msg: FrameMessage): Frame {
         }
     }
 
-    if (msg.simbox) {
-        frame.simbox = new Box(
-            msg.simbox.h,
-            msg.simbox.origin,
-            msg.simbox.pbc[0],
-            msg.simbox.pbc[1],
-            msg.simbox.pbc[2],
+    if (msg.box) {
+        frame.box = new Box(
+            msg.box.h,
+            msg.box.origin,
+            msg.box.pbc[0],
+            msg.box.pbc[1],
+            msg.box.pbc[2],
         );
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "molvis",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "interactive molecule visulization package",
   "author": "Roy Kid",
   "license": "BSD-3-Clause",
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@molcrafts/molplot": "^0.1.1",
-    "@molcrafts/molrs": "^0.8.2",
+    "@molcrafts/molrs": "0.9.0",
     "vega": "^5.30.0",
     "vega-embed": "^6.29.0",
     "vega-lite": "^5.21.0"

--- a/page/package.json
+++ b/page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "page",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "index.js",
   "type": "module",
   "keywords": [],

--- a/page/src/ui/layout/ClusterPanel.tsx
+++ b/page/src/ui/layout/ClusterPanel.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/select";
 import { SidebarSection } from "@/ui/layout/SidebarSection";
 import { AnalysisAlert } from "./analysis/AnalysisAlert";
+import { AnalysisChart } from "./analysis/AnalysisChart";
 import { AnalysisPanelShell } from "./analysis/AnalysisPanelShell";
 import { AnalysisRunBar } from "./analysis/AnalysisRunBar";
 import { ParamStack } from "./analysis/ParamStack";
@@ -40,11 +41,7 @@ interface ModifierOption {
 }
 
 function ClusterSizeChart({ result }: { result: ClusterResult }) {
-  const [plotDiv, setPlotDiv] = useState<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    const div = plotDiv;
-    if (!div) return;
+  const controller = useMemo(() => {
     const { clusterSizes, numClusters } = result;
     const histogram = new Map<number, number>();
     for (let c = 0; c < numClusters; c++) {
@@ -58,19 +55,28 @@ function ClusterSizeChart({ result }: { result: ClusterResult }) {
         y: count,
         text: `${count} cluster${count === 1 ? "" : "s"} of size ${size}`,
       }));
-    if (points.length === 0) return;
-    const chart = new BarChart(div, {
-      series: [{ id: "sizes", label: "clusters", points }],
-      orientation: "v",
-      xAxis: { label: "cluster size", dtype: "category" },
-      yAxis: { label: "count", rangemode: "tozero" },
-    });
-    return () => {
-      chart.dispose();
+    return {
+      mount: (el: HTMLElement) => {
+        if (points.length === 0) return { dispose: () => undefined };
+        const chart = new BarChart(el, {
+          series: [{ id: "sizes", label: "clusters", points }],
+          orientation: "v",
+          xAxis: { label: "cluster size", dtype: "category" },
+          yAxis: { label: "count", rangemode: "tozero" },
+          showLegend: true,
+        });
+        return { dispose: () => chart.dispose() };
+      },
     };
-  }, [plotDiv, result]);
+  }, [result]);
 
-  return <div ref={setPlotDiv} className="h-40 w-full min-h-36" />;
+  return (
+    <AnalysisChart
+      controller={controller}
+      chartKey={`${result.numClusters}-${result.nParticles}`}
+      title="Cluster sizes"
+    />
+  );
 }
 
 const TABLE_ROW_HEIGHT = 22;

--- a/page/src/ui/layout/PCATool.tsx
+++ b/page/src/ui/layout/PCATool.tsx
@@ -27,6 +27,10 @@ import {
 import { cn } from "@/lib/utils";
 import { SidebarSection } from "@/ui/layout/SidebarSection";
 import { AnalysisAlert } from "./analysis/AnalysisAlert";
+import {
+  AnalysisChart,
+  type AnalysisChartController,
+} from "./analysis/AnalysisChart";
 import { AnalysisPanelShell } from "./analysis/AnalysisPanelShell";
 import { AnalysisRunBar } from "./analysis/AnalysisRunBar";
 import { ParamStack } from "./analysis/ParamStack";
@@ -152,8 +156,6 @@ export function PCATool({
   const [computing, setComputing] = useState(false);
   const [computeError, setComputeError] = useState<string | null>(null);
   const [resultKey, setResultKey] = useState<string | null>(null);
-
-  const [plotDiv, setPlotDiv] = useState<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (!app) return;
@@ -331,55 +333,67 @@ export function PCATool({
     [exploration],
   );
 
-  useEffect(() => {
-    const div = plotDiv;
-    if (!div || !exploration || !app) return;
+  const scatterController = useMemo<AnalysisChartController | null>(() => {
+    if (!exploration || !app) return null;
+    const explorationSnap = exploration;
+    const colorBySnap = colorBy;
+    const axesSnap = axes;
+    const frameLabelsSnap = frameLabels;
+    return {
+      mount: (el) => {
+        const { coords } = explorationSnap.embedding;
+        const pointCount = coords.length / 2;
+        const points: ScatterPoint[] = new Array(pointCount);
+        for (let i = 0; i < pointCount; i++) {
+          points[i] = {
+            x: coords[2 * i],
+            y: coords[2 * i + 1],
+            customdata: i,
+          };
+        }
 
-    const { coords } = exploration.embedding;
-    const pointCount = coords.length / 2;
-    const points: ScatterPoint[] = new Array(pointCount);
-    for (let i = 0; i < pointCount; i++) {
-      points[i] = { x: coords[2 * i], y: coords[2 * i + 1], customdata: i };
-    }
+        const chart = new ScatterChart(el, {
+          points,
+          xAxis: { label: axesSnap[0] },
+          yAxis: { label: axesSnap[1] },
+          marker: {
+            size: 6,
+            ...buildMarker(colorBySnap, explorationSnap, frameLabelsSnap),
+          },
+          highlight: { index: app.system.trajectory.currentIndex ?? 0 },
+          hovertemplate:
+            "frame #%{customdata}<br>%{x:.3f}, %{y:.3f}<extra></extra>",
+        });
 
-    const chart = new ScatterChart(div, {
-      points,
-      xAxis: { label: axes[0] },
-      yAxis: { label: axes[1] },
-      marker: {
-        size: 6,
-        ...buildMarker(colorBy, exploration, frameLabels),
+        const offClick = chart.onPointClick((e) => {
+          if (typeof e.customdata === "number") app.seekFrame(e.customdata);
+        });
+
+        let rafId: number | null = null;
+        let pending: number | null = null;
+        const flush = () => {
+          rafId = null;
+          const i = pending;
+          pending = null;
+          if (i === null || i < 0 || i >= pointCount) return;
+          chart.setHighlight(i);
+        };
+        const offFrame = app.events.on("frame-change", (i) => {
+          pending = i;
+          if (rafId === null) rafId = requestAnimationFrame(flush);
+        });
+
+        return {
+          dispose: () => {
+            offClick();
+            offFrame();
+            if (rafId !== null) cancelAnimationFrame(rafId);
+            chart.dispose();
+          },
+        };
       },
-      highlight: { index: app.system.trajectory.currentIndex ?? 0 },
-      hovertemplate:
-        "frame #%{customdata}<br>%{x:.3f}, %{y:.3f}<extra></extra>",
-    });
-
-    const offClick = chart.onPointClick((e) => {
-      if (typeof e.customdata === "number") app.seekFrame(e.customdata);
-    });
-
-    let rafId: number | null = null;
-    let pending: number | null = null;
-    const flush = () => {
-      rafId = null;
-      const i = pending;
-      pending = null;
-      if (i === null || i < 0 || i >= pointCount) return;
-      chart.setHighlight(i);
     };
-    const offFrame = app.events.on("frame-change", (i) => {
-      pending = i;
-      if (rafId === null) rafId = requestAnimationFrame(flush);
-    });
-
-    return () => {
-      offClick();
-      offFrame();
-      if (rafId !== null) cancelAnimationFrame(rafId);
-      chart.dispose();
-    };
-  }, [app, plotDiv, exploration, colorBy, axes, frameLabels]);
+  }, [app, exploration, colorBy, axes, frameLabels]);
 
   const hasDescriptors = descriptors.length > 0;
 
@@ -598,14 +612,16 @@ export function PCATool({
         />
       )}
 
-      {exploration && (
+      {exploration && scatterController && (
         <ResultSection subtitle={`${axes[0]} · ${axes[1]}`} stale={stale}>
-          <div
-            ref={setPlotDiv}
-            className="h-52 min-h-44 w-full"
-            role="img"
-            aria-label="PCA scatter map"
-          />
+          <div role="img" aria-label="PCA scatter map">
+            <AnalysisChart
+              controller={scatterController}
+              chartKey={`${resultKey ?? "pca"}-${axes[0]}-${axes[1]}-${colorBy.kind}`}
+              title={`PCA · ${axes[0]} vs ${axes[1]}`}
+              className="h-56 min-h-52"
+            />
+          </div>
         </ResultSection>
       )}
     </AnalysisPanelShell>

--- a/page/src/ui/layout/analysis/AnalysisChart.tsx
+++ b/page/src/ui/layout/analysis/AnalysisChart.tsx
@@ -1,0 +1,310 @@
+import { Expand, X } from "lucide-react";
+import type React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+/**
+ * Imperative chart lifecycle used by {@link AnalysisChart}.
+ * Each mount of the host (inline or modal) calls `mount` once and
+ * `dispose` on teardown — charts that hold Vega views must not share
+ * a container across both hosts.
+ */
+export interface AnalysisChartController {
+  mount: (el: HTMLElement) => { dispose: () => void };
+}
+
+interface AnalysisChartProps {
+  /** Build the chart into `el`; return a dispose handle. */
+  controller: AnalysisChartController;
+  /** Re-mount key — change when data/config identity changes. */
+  chartKey: string | number;
+  title?: string;
+  /** Fixed height class for the inline host. Default fills a tall sidebar slot. */
+  className?: string;
+  /** Extra class on the modal chart area. */
+  modalClassName?: string;
+}
+
+const MODAL_DEFAULT = { w: 720, h: 520 };
+const MODAL_MIN = { w: 360, h: 280 };
+
+/**
+ * Bump Vega/molplot axis label + tick font sizes after embed. molplot's
+ * AxisConfig.tickfont is typed but not yet wired through the VL builder, so
+ * we patch the rendered SVG once and on resize-driven re-embeds via a
+ * MutationObserver on the host.
+ */
+function boostChartFonts(host: HTMLElement, scale = 1.35): void {
+  const texts = host.querySelectorAll("svg text");
+  for (const node of texts) {
+    const el = node as SVGTextElement;
+    if (el.dataset.molvisFontBoosted === "1") continue;
+    const attr = el.getAttribute("font-size");
+    const base = attr ? Number.parseFloat(attr) : Number.NaN;
+    if (!Number.isFinite(base) || base <= 0) continue;
+    // Axis titles (role-axis-title) get a slightly larger bump than ticks.
+    const role = el.closest(".role-axis-title, .role-axis-label, .role-legend");
+    const factor = role?.classList.contains("role-axis-title")
+      ? scale * 1.1
+      : scale;
+    el.setAttribute("font-size", String(Math.round(base * factor * 10) / 10));
+    el.dataset.molvisFontBoosted = "1";
+  }
+}
+
+function ChartMount({
+  controller,
+  chartKey,
+  className,
+}: {
+  controller: AnalysisChartController;
+  chartKey: string | number;
+  className?: string;
+}) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const el = hostRef.current;
+    if (!el) return;
+
+    // Clear any prior SVG before remount (dispose should already do this).
+    // `chartKey` is recorded so identity changes force a full remount.
+    el.dataset.chartKey = String(chartKey);
+    el.replaceChildren();
+    const handle = controller.mount(el);
+
+    const apply = () => boostChartFonts(el);
+    // Initial embed is async; observe for SVG insertion + re-embeds.
+    const mo = new MutationObserver(apply);
+    mo.observe(el, { childList: true, subtree: true });
+    // Also try after a couple of frames in case the embed is already done.
+    const t0 = requestAnimationFrame(apply);
+    const t1 = window.setTimeout(apply, 50);
+    const t2 = window.setTimeout(apply, 200);
+
+    return () => {
+      mo.disconnect();
+      cancelAnimationFrame(t0);
+      window.clearTimeout(t1);
+      window.clearTimeout(t2);
+      handle.dispose();
+      el.replaceChildren();
+    };
+  }, [controller, chartKey]);
+
+  return (
+    <div
+      ref={hostRef}
+      className={cn(
+        // Fill the allocated box; molplot reads getBoundingClientRect and
+        // re-embeds on resize, so a real non-zero size is required.
+        "analysis-chart relative h-full w-full min-h-0 min-w-0",
+        className,
+      )}
+    />
+  );
+}
+
+type ResizeEdge = "e" | "s" | "se";
+
+/**
+ * Shared analysis-panel chart host:
+ * - fills its container (callers size the outer box)
+ * - bumps axis label/tick fonts for sidebar density
+ * - optional pop-out modal with a larger remount of the same chart
+ * - modal is drag-resizable from edges / SE corner
+ */
+export const AnalysisChart: React.FC<AnalysisChartProps> = ({
+  controller,
+  chartKey,
+  title = "Chart",
+  className,
+  modalClassName,
+}) => {
+  const [open, setOpen] = useState(false);
+  const [size, setSize] = useState(MODAL_DEFAULT);
+  const dragRef = useRef<{
+    edge: ResizeEdge;
+    startX: number;
+    startY: number;
+    startW: number;
+    startH: number;
+  } | null>(null);
+
+  const onOpenChange = useCallback((next: boolean) => {
+    setOpen(next);
+    if (next) setSize(MODAL_DEFAULT);
+  }, []);
+
+  const onResizePointerDown = useCallback(
+    (edge: ResizeEdge) => (e: React.PointerEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const target = e.currentTarget as HTMLElement;
+      target.setPointerCapture(e.pointerId);
+      dragRef.current = {
+        edge,
+        startX: e.clientX,
+        startY: e.clientY,
+        startW: size.w,
+        startH: size.h,
+      };
+    },
+    [size.h, size.w],
+  );
+
+  const onResizePointerMove = useCallback((e: React.PointerEvent) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    const dx = e.clientX - drag.startX;
+    const dy = e.clientY - drag.startY;
+    const maxW = Math.min(window.innerWidth - 32, window.innerWidth * 0.96);
+    const maxH = Math.min(window.innerHeight - 32, window.innerHeight * 0.92);
+    setSize({
+      w:
+        drag.edge === "s"
+          ? drag.startW
+          : Math.min(maxW, Math.max(MODAL_MIN.w, drag.startW + dx)),
+      h:
+        drag.edge === "e"
+          ? drag.startH
+          : Math.min(maxH, Math.max(MODAL_MIN.h, drag.startH + dy)),
+    });
+  }, []);
+
+  const onResizePointerUp = useCallback((e: React.PointerEvent) => {
+    if (!dragRef.current) return;
+    dragRef.current = null;
+    try {
+      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {
+      // capture may already be released
+    }
+  }, []);
+
+  return (
+    <>
+      <div
+        className={cn(
+          // Default inline footprint: full width, tall enough for readable axes.
+          // group: pop-out stays hidden until the chart host is hovered/focused.
+          "group/chart relative w-full min-h-[14rem] h-56",
+          className,
+        )}
+      >
+        <ChartMount controller={controller} chartKey={`inline-${chartKey}`} />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              size="icon-sm"
+              variant="ghost"
+              className={cn(
+                "absolute right-1 top-1 z-10 h-6 w-6 border-0 bg-background/70 p-0 shadow-none backdrop-blur-sm",
+                "opacity-0 pointer-events-none transition-opacity",
+                "group-hover/chart:opacity-100 group-hover/chart:pointer-events-auto",
+                "group-focus-within/chart:opacity-100 group-focus-within/chart:pointer-events-auto",
+                "hover:bg-background/90 focus-visible:opacity-100 focus-visible:pointer-events-auto",
+              )}
+              onClick={() => setOpen(true)}
+              aria-label="Pop out chart"
+            >
+              <Expand className="h-3.5 w-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="left">Pop out</TooltipContent>
+        </Tooltip>
+      </div>
+
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent
+          showCloseButton={false}
+          className={cn(
+            // Drop the default max-w so our pixel size fully controls layout.
+            "flex flex-col gap-2 overflow-hidden p-3 sm:max-w-none",
+            modalClassName,
+          )}
+          style={{
+            width: size.w,
+            height: size.h,
+            maxWidth: "96vw",
+            maxHeight: "92vh",
+          }}
+        >
+          <DialogHeader className="flex shrink-0 flex-row items-center justify-between space-y-0 pr-0">
+            <DialogTitle className="text-sm font-medium">{title}</DialogTitle>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  size="icon-sm"
+                  variant="ghost"
+                  className="h-7 w-7 border-0 p-0 shadow-none"
+                  onClick={() => setOpen(false)}
+                  aria-label="Close"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="left">Close</TooltipContent>
+            </Tooltip>
+          </DialogHeader>
+
+          <div className="relative min-h-0 w-full flex-1">
+            {open && (
+              <ChartMount
+                controller={controller}
+                // Size changes are handled by molplot's ResizeObserver — do
+                // not fold size into chartKey or every drag frame remounts.
+                chartKey={`modal-${chartKey}`}
+                className="h-full min-h-0"
+              />
+            )}
+          </div>
+
+          {/* Resize handles — E / S edges + SE corner (mouse/touch only). */}
+          <div
+            aria-hidden
+            className="absolute top-3 right-0 bottom-3 w-1.5 cursor-ew-resize touch-none"
+            onPointerDown={onResizePointerDown("e")}
+            onPointerMove={onResizePointerMove}
+            onPointerUp={onResizePointerUp}
+            onPointerCancel={onResizePointerUp}
+          />
+          <div
+            aria-hidden
+            className="absolute right-3 bottom-0 left-3 h-1.5 cursor-ns-resize touch-none"
+            onPointerDown={onResizePointerDown("s")}
+            onPointerMove={onResizePointerMove}
+            onPointerUp={onResizePointerUp}
+            onPointerCancel={onResizePointerUp}
+          />
+          <div
+            aria-hidden
+            className="absolute right-0 bottom-0 h-4 w-4 cursor-nwse-resize touch-none"
+            onPointerDown={onResizePointerDown("se")}
+            onPointerMove={onResizePointerMove}
+            onPointerUp={onResizePointerUp}
+            onPointerCancel={onResizePointerUp}
+          >
+            {/* Grip mark: two diagonal ticks at the SE corner */}
+            <span className="pointer-events-none absolute right-1 bottom-1.5 block h-px w-2.5 origin-bottom-right rotate-[-45deg] bg-muted-foreground/60" />
+            <span className="pointer-events-none absolute right-1 bottom-1 block h-px w-1.5 origin-bottom-right rotate-[-45deg] bg-muted-foreground/60" />
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};

--- a/page/src/ui/layout/analysis/AnalysisRunBar.tsx
+++ b/page/src/ui/layout/analysis/AnalysisRunBar.tsx
@@ -1,6 +1,11 @@
 import { Loader2, Play } from "lucide-react";
 import type React from "react";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 export interface AnalysisProgress {
@@ -13,7 +18,7 @@ interface AnalysisRunBarProps {
   disabled?: boolean;
   running?: boolean;
   progress?: AnalysisProgress | null;
-  /** Primary label when idle, e.g. "Compute RDF". */
+  /** Primary label when idle, e.g. "Compute RDF" — shown in tooltip. */
   label?: string;
   /** One-line context shown above the button (frame count, groups…). */
   summary?: string;
@@ -25,6 +30,7 @@ interface AnalysisRunBarProps {
 /**
  * Footer run control for the analysis side panel. Renders as a true column
  * footer (via {@link AnalysisPanelShell}), not sticky mid-scroll content.
+ * Icon-only primary action; the full label lives in the tooltip.
  */
 export const AnalysisRunBar: React.FC<AnalysisRunBarProps> = ({
   onRun,
@@ -40,6 +46,11 @@ export const AnalysisRunBar: React.FC<AnalysisRunBarProps> = ({
     running && progress && progress.total > 0
       ? `${progress.completed}/${progress.total}`
       : null;
+  const tip = running
+    ? progressLabel
+      ? `Running… ${progressLabel}`
+      : "Running…"
+    : label;
 
   return (
     <div
@@ -53,24 +64,25 @@ export const AnalysisRunBar: React.FC<AnalysisRunBarProps> = ({
           {summary}
         </p>
       )}
-      <Button
-        size="sm"
-        className="h-7 w-full gap-1.5 text-xs"
-        onClick={onRun}
-        disabled={disabled || running}
-        aria-busy={running}
-      >
-        {running ? (
-          <Loader2 className="h-3.5 w-3.5 animate-spin" />
-        ) : (
-          <Play className="h-3.5 w-3.5" />
-        )}
-        {running
-          ? progressLabel
-            ? `Running… ${progressLabel}`
-            : "Running…"
-          : label}
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            size="sm"
+            className="h-7 w-full gap-1.5 border-0 px-0 text-xs"
+            onClick={onRun}
+            disabled={disabled || running}
+            aria-busy={running}
+            aria-label={tip}
+          >
+            {running ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Play className="h-3.5 w-3.5" />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top">{tip}</TooltipContent>
+      </Tooltip>
       {running && progress && progress.total > 0 && (
         <div
           className="h-0.5 overflow-hidden rounded-full bg-muted"

--- a/page/src/ui/layout/analysis/MsdPanel.tsx
+++ b/page/src/ui/layout/analysis/MsdPanel.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/select";
 import { SidebarSection } from "@/ui/layout/SidebarSection";
 import { AnalysisAlert } from "./AnalysisAlert";
+import { AnalysisChart, type AnalysisChartController } from "./AnalysisChart";
 import { AnalysisPanelShell } from "./AnalysisPanelShell";
 import { AnalysisRunBar } from "./AnalysisRunBar";
 import { ParamStack } from "./ParamStack";
@@ -29,28 +30,33 @@ import {
 } from "./selectionOptions";
 
 function MsdChart({ result }: { result: MsdTrajectoryResult }) {
-  const [plotDiv, setPlotDiv] = useState<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    const div = plotDiv;
-    if (!div) return;
+  const controller = useMemo<AnalysisChartController>(() => {
     const points: SeriesPoint[] = result.result.frames.map((frame, i) => ({
       x: result.frameIndices[i],
       y: frame.mean,
     }));
-    const chart = new LineChart(div, {
-      series: [
-        { id: "msd", label: "MSD", initialPoints: points, mode: "lines" },
-      ],
-      xAxis: { label: "Frame", rangemode: "tozero" },
-      yAxis: { label: "MSD (Å²)", rangemode: "tozero" },
-    });
-    return () => {
-      chart.dispose();
+    return {
+      mount: (el) => {
+        const chart = new LineChart(el, {
+          series: [
+            { id: "msd", label: "MSD", initialPoints: points, mode: "lines" },
+          ],
+          xAxis: { label: "Frame", rangemode: "tozero" },
+          yAxis: { label: "MSD (Å²)", rangemode: "tozero" },
+          showLegend: true,
+        });
+        return { dispose: () => chart.dispose() };
+      },
     };
-  }, [plotDiv, result]);
+  }, [result]);
 
-  return <div ref={setPlotDiv} className="h-44 w-full min-h-40" />;
+  return (
+    <AnalysisChart
+      controller={controller}
+      chartKey={result.frameIndices.join(",")}
+      title="MSD"
+    />
+  );
 }
 
 function downloadMsdCsv(result: MsdTrajectoryResult) {

--- a/page/src/ui/layout/analysis/RdfPanel.tsx
+++ b/page/src/ui/layout/analysis/RdfPanel.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/select";
 import { SidebarSection } from "@/ui/layout/SidebarSection";
 import { AnalysisAlert } from "./AnalysisAlert";
+import { AnalysisChart, type AnalysisChartController } from "./AnalysisChart";
 import { AnalysisPanelShell } from "./AnalysisPanelShell";
 import { AnalysisRunBar } from "./AnalysisRunBar";
 import { ParamStack } from "./ParamStack";
@@ -31,27 +32,32 @@ import {
 } from "./selectionOptions";
 
 function RdfChart({ result }: { result: RdfResult }) {
-  const [plotDiv, setPlotDiv] = useState<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    const div = plotDiv;
-    if (!div) return;
+  const controller = useMemo<AnalysisChartController>(() => {
     const { r, gr, nBins } = result;
     const points: SeriesPoint[] = new Array(nBins);
     for (let i = 0; i < nBins; i++) points[i] = { x: r[i], y: gr[i] };
-    const chart = new LineChart(div, {
-      series: [
-        { id: "gr", label: "g(r)", initialPoints: points, mode: "lines" },
-      ],
-      xAxis: { label: "r (Å)", rangemode: "tozero" },
-      yAxis: { label: "g(r)", rangemode: "tozero" },
-    });
-    return () => {
-      chart.dispose();
+    return {
+      mount: (el) => {
+        const chart = new LineChart(el, {
+          series: [
+            { id: "gr", label: "g(r)", initialPoints: points, mode: "lines" },
+          ],
+          xAxis: { label: "r (Å)", rangemode: "tozero" },
+          yAxis: { label: "g(r)", rangemode: "tozero" },
+          showLegend: true,
+        });
+        return { dispose: () => chart.dispose() };
+      },
     };
-  }, [plotDiv, result]);
+  }, [result]);
 
-  return <div ref={setPlotDiv} className="h-44 w-full min-h-40" />;
+  return (
+    <AnalysisChart
+      controller={controller}
+      chartKey={`${result.nBins}-${result.rMax}`}
+      title="RDF g(r)"
+    />
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -245,11 +251,11 @@ export function RdfPanel({
 
   useEffect(() => {
     if (!app) return;
-    // `frame.simbox` yields a fresh Box wrapper on every access, so compare by
+    // `frame.box` yields a fresh Box wrapper on every access, so compare by
     // the numeric volume (stable across ticks) and free the transient wrapper.
     let lastVolume: number | null = Number.NaN;
     const syncBoxVolume = () => {
-      const box = app.system.frame?.simbox;
+      const box = app.system.frame?.box;
       const v = box ? box.volume() : null;
       box?.free();
       if (v === lastVolume) return;
@@ -290,7 +296,7 @@ export function RdfPanel({
       volume.trim() === "" ? Number.NaN : Number.parseFloat(volume);
     let volumeParam: number | undefined;
     if (hasBox) {
-      const box = frame.simbox;
+      const box = frame.box;
       const boxVol = box ? box.volume() : Number.NaN;
       box?.free();
       if (

--- a/page/src/ui/layout/analysis/ResultSection.tsx
+++ b/page/src/ui/layout/analysis/ResultSection.tsx
@@ -1,8 +1,13 @@
-import { Download } from "lucide-react";
+import { ChartLine, Download, Table2 } from "lucide-react";
 import type React from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { SidebarSection } from "@/ui/layout/SidebarSection";
 import { AnalysisAlert } from "./AnalysisAlert";
 
@@ -25,6 +30,34 @@ interface ResultSectionProps {
   defaultOpen?: boolean;
 }
 
+function IconTipButton({
+  label,
+  onClick,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          size="icon-sm"
+          variant="ghost"
+          className="h-7 w-7 border-0 p-0 shadow-none"
+          onClick={onClick}
+          aria-label={label}
+        >
+          {children}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
 /**
  * Shared Result block: optional Chart | Data tabs, export, stale + failures.
  */
@@ -32,7 +65,7 @@ export const ResultSection: React.FC<ResultSectionProps> = ({
   subtitle,
   stale = false,
   onExport,
-  exportLabel = "CSV",
+  exportLabel = "Export CSV",
   failures = 0,
   chart,
   data,
@@ -69,24 +102,31 @@ export const ResultSection: React.FC<ResultSectionProps> = ({
         <Tabs defaultValue="chart" className="w-full gap-1.5">
           <div className="flex items-center justify-between gap-2">
             <TabsList className="h-7" variant="default">
-              <TabsTrigger value="chart" className="px-2.5 text-xs">
-                Chart
-              </TabsTrigger>
-              <TabsTrigger value="data" className="px-2.5 text-xs">
-                Data
-              </TabsTrigger>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <TabsTrigger
+                    value="chart"
+                    className="px-2"
+                    aria-label="Chart"
+                  >
+                    <ChartLine className="h-3.5 w-3.5" />
+                  </TabsTrigger>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Chart</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <TabsTrigger value="data" className="px-2" aria-label="Data">
+                    <Table2 className="h-3.5 w-3.5" />
+                  </TabsTrigger>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Data</TooltipContent>
+              </Tooltip>
             </TabsList>
             {onExport && (
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                className="h-7 gap-1 px-2 text-xs"
-                onClick={onExport}
-              >
+              <IconTipButton label={exportLabel} onClick={onExport}>
                 <Download className="h-3.5 w-3.5" />
-                {exportLabel}
-              </Button>
+              </IconTipButton>
             )}
           </div>
           <TabsContent value="chart" className="mt-0">
@@ -100,16 +140,9 @@ export const ResultSection: React.FC<ResultSectionProps> = ({
         <>
           {onExport && (
             <div className="mb-1.5 flex justify-end">
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                className="h-7 gap-1 px-2 text-xs"
-                onClick={onExport}
-              >
+              <IconTipButton label={exportLabel} onClick={onExport}>
                 <Download className="h-3.5 w-3.5" />
-                {exportLabel}
-              </Button>
+              </IconTipButton>
             </div>
           )}
           {chart ?? children}

--- a/page/src/ui/layout/analysis/ResultView.tsx
+++ b/page/src/ui/layout/analysis/ResultView.tsx
@@ -1,7 +1,8 @@
 import { LineChart, type SeriesPoint } from "@molcrafts/molplot";
 import type { AnalysisResultKind } from "@molvis/core";
 import type React from "react";
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
+import { AnalysisChart, type AnalysisChartController } from "./AnalysisChart";
 
 /**
  * Render an analysis payload by its catalog `resultKind`.
@@ -31,34 +32,36 @@ const X_KEYS = ["binCenters", "lagTimes", "frequencies", "r", "centers", "x"];
 const Y_KEYS = ["rdf", "values", "intensities", "gr", "density", "counts", "y"];
 
 function LineResult({ payload, label }: { payload: Payload; label: string }) {
-  const [host, setHost] = useState<HTMLDivElement | null>(null);
-  const x = pick(payload, X_KEYS);
-  const y = pick(payload, Y_KEYS);
-  const plottable = x.length > 0 && y.length > 0;
-
-  useEffect(() => {
-    if (!host || !plottable) return;
+  const controller = useMemo<AnalysisChartController | null>(() => {
+    const x = pick(payload, X_KEYS);
+    const y = pick(payload, Y_KEYS);
+    if (x.length === 0 || y.length === 0) return null;
     const n = Math.min(x.length, y.length);
     const initialPoints: SeriesPoint[] = Array.from({ length: n }, (_, i) => ({
       x: x[i],
       y: y[i],
     }));
-    const chart = new LineChart(host, {
-      series: [{ id: "result", label, initialPoints, mode: "lines" }],
-      xAxis: { rangemode: "tozero" },
-      yAxis: { label, rangemode: "tozero" },
-    });
-    return () => {
-      chart.dispose();
+    return {
+      mount: (el) => {
+        const chart = new LineChart(el, {
+          series: [{ id: "result", label, initialPoints, mode: "lines" }],
+          xAxis: { rangemode: "tozero" },
+          yAxis: { label, rangemode: "tozero" },
+          showLegend: true,
+        });
+        return { dispose: () => chart.dispose() };
+      },
     };
-  }, [host, x, y, label, plottable]);
+  }, [payload, label]);
 
-  if (!plottable) {
+  if (!controller) {
     return (
       <EmptyResult reason="the payload carries no plottable x/y columns" />
     );
   }
-  return <div ref={setHost} className="h-48 w-full" />;
+  return (
+    <AnalysisChart controller={controller} chartKey={label} title={label} />
+  );
 }
 
 function BarResult({ payload }: { payload: Payload }) {

--- a/page/src/ui/modes/view/modifiers/DataSourceModifier.tsx
+++ b/page/src/ui/modes/view/modifiers/DataSourceModifier.tsx
@@ -44,7 +44,7 @@ function readFrameStats(modifier: CoreDataSourceModifier): FrameStats {
   }
   const atoms = frame.getBlock("atoms");
   const bonds = frame.getBlock("bonds");
-  const box = frame.simbox;
+  const box = frame.box;
   let boxLabel: string | null = null;
   if (box) {
     try {

--- a/page/src/ui/modes/view/pipeline/PipelineList.tsx
+++ b/page/src/ui/modes/view/pipeline/PipelineList.tsx
@@ -142,7 +142,7 @@ function drawBoxSpecFromForm(form: DrawBoxForm): DrawBoxSpec | null {
 }
 
 function drawBoxFormFromApp(app: Molvis | null): DrawBoxForm {
-  const box = app?.frame?.simbox;
+  const box = app?.frame?.box;
   if (!box) return DEFAULT_DRAW_BOX_FORM;
   try {
     const lengths = box.lengths();

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "molcrafts-molvis"
-version = "0.1.0"
+version = "0.1.1"
 description = "Molecular visualization driven by a local WebSocket-hosted page"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/vsc-ext/package.json
+++ b/vsc-ext/package.json
@@ -12,7 +12,7 @@
   },
   "license": "BSD-3-Clause",
   "icon": "image/molvis-icon.png",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "engines": {
     "vscode": "^1.120.0"
   },

--- a/vsc-ext/rslib.webview.config.mts
+++ b/vsc-ext/rslib.webview.config.mts
@@ -178,10 +178,27 @@ export default defineConfig({
               enforce: true,
               chunks: "all",
             },
+            // Deps required from modules that live in the molvis-core chunk
+            // MUST share that chunk (and its runtime), not vendor.
+            // vendor uses `chunks/runtime.js`; molvis-core is wired to a
+            // separate wasm-aware runtime (`96612.js`). Modules registered
+            // only on runtime.js are invisible to 96612's `__webpack_require__`,
+            // which throws `f[e] is not a function` at load time.
+            // Same chunk name as molvisCore → rspack merges them.
+            //
+            // molrs: wasm glue, async-imported from core.
+            // tslog: sync-imported by core/src/utils/logger.ts (top-level).
             molrs: {
-              name: "chunks/molrs",
+              name: "chunks/molvis-core",
               test: /[\\/]node_modules[\\/]@molcrafts[\\/]molrs[\\/]/,
-              priority: 35,
+              priority: 45,
+              enforce: true,
+              chunks: "all",
+            },
+            tslog: {
+              name: "chunks/molvis-core",
+              test: /[\\/]node_modules[\\/]tslog[\\/]/,
+              priority: 45,
               enforce: true,
               chunks: "all",
             },

--- a/vsc-ext/src/extension/activate.ts
+++ b/vsc-ext/src/extension/activate.ts
@@ -80,9 +80,16 @@ export function activate(context: vscode.ExtensionContext): void {
       },
     ),
     vscode.commands.registerCommand("molvis.openEditor", (arg?: unknown) => {
-      const target = uriFromLauncherArg(arg) ?? resolveActiveUri();
-      recordRecent(target);
-      openEditorPanel(context, panelRegistry, logger, fileLoader, target);
+      try {
+        // Launcher "Open Workspace" has no URI; explorer may pass one.
+        // Never require an active file — empty workspace editor is valid.
+        const target = uriFromLauncherArg(arg) ?? resolveActiveUri();
+        recordRecent(target);
+        openEditorPanel(context, panelRegistry, logger, fileLoader, target);
+      } catch (err) {
+        const text = err instanceof Error ? err.message : String(err);
+        logger.error(`MolVis: Open Workspace failed: ${text}`);
+      }
     }),
     vscode.commands.registerCommand("molvis.openStructure", async () => {
       const picked = await pickMolecularUri();

--- a/vsc-ext/src/extension/panels/html.ts
+++ b/vsc-ext/src/extension/panels/html.ts
@@ -34,7 +34,13 @@ function getViewerCssUri(
 
 function getNonce(): string {
   const bytes = new Uint8Array(16);
-  crypto.getRandomValues(bytes);
+  if (typeof globalThis.crypto?.getRandomValues === "function") {
+    globalThis.crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = Math.floor(Math.random() * 256);
+    }
+  }
   let nonce = "";
   for (const byte of bytes) {
     nonce += byte.toString(16).padStart(2, "0");

--- a/vsc-ext/src/extension/panels/launcherView.ts
+++ b/vsc-ext/src/extension/panels/launcherView.ts
@@ -114,10 +114,12 @@ export class MolvisLauncherViewProvider
           vscode.TreeItemCollapsibleState.None,
         );
         item.iconPath = new vscode.ThemeIcon(element.icon);
+        // Only set `arguments` when present. Passing `arguments: undefined`
+        // has caused some VS Code builds to drop the command on tree click.
         item.command = {
           command: element.command,
           title: element.label,
-          arguments: element.args,
+          ...(element.args !== undefined ? { arguments: element.args } : {}),
         };
         item.description = element.description;
         item.contextValue = `molvis.action.${element.id}`;

--- a/vsc-ext/src/extension/panels/viewerPanel.ts
+++ b/vsc-ext/src/extension/panels/viewerPanel.ts
@@ -20,10 +20,13 @@ export function openEditorPanel(
   uri?: vscode.Uri,
 ): void {
   const title = uri ? `MolVis: ${getDisplayName(uri)}` : "MolVis Editor";
+  // ViewColumn.One (not Active): when the user clicks the activity-bar
+  // launcher the active group is often the sidebar, and Active can fail to
+  // surface a usable editor tab. One always opens in the first editor column.
   const panel = vscode.window.createWebviewPanel(
     "molvis.workspace",
     title,
-    vscode.ViewColumn.Active,
+    { viewColumn: vscode.ViewColumn.One, preserveFocus: false },
     {
       enableScripts: true,
       retainContextWhenHidden: true,

--- a/vsc-ext/src/viewer/index.tsx
+++ b/vsc-ext/src/viewer/index.tsx
@@ -1,11 +1,29 @@
-import { createRoot } from "react-dom/client";
-import App from "@/App";
+/**
+ * VSCode editor-tab entry for the full MolVis page (Open Workspace).
+ *
+ * Must mirror page/src/index.tsx: host mount opts from
+ * `window.__MOLVIS_VSCODE_INIT__`, theme bootstrap, and MountOptsProvider.
+ * Rendering bare `<App />` skips surface/chrome flags and theme init.
+ */
+import { bootstrapTheme } from "@/hooks/useTheme";
+import { mountMolvisApp } from "@/lib/mount";
+import { readMountOptsFromHost } from "@/lib/mount-opts";
 import "./main.css";
 
+bootstrapTheme();
+// Force dark chrome in the VSCode webview (host theme tokens still apply
+// via CSS variables where present; class ensures Tailwind dark: variants).
 document.documentElement.classList.add("dark");
 
 const container = document.getElementById("root");
 if (container) {
-  const root = createRoot(container);
-  root.render(<App />);
+  const hostOpts = readMountOptsFromHost();
+  mountMolvisApp(container, {
+    ...hostOpts,
+    // Host HTML injects mount.surface = "full"; default to full if missing.
+    surface: hostOpts.surface ?? "full",
+    useShadowDOM: false,
+  });
+} else {
+  console.error("[MolVis] #root missing — Open Workspace webview cannot mount");
 }


### PR DESCRIPTION
## Summary
- Pin `@molcrafts/molrs` to **0.9.0** and sync Frame API: `frame.simbox` → `frame.box`, streaming `boxH` / `boxOrigin` / `boxPbc`.
- Fix VS Code webview dual-runtime crash (`tslog` not a function) by co-locating tslog with the molvis-core wasm chunk.
- Multi-frame XYZ blank-line handling (via molrs 0.9.0) + regression tests / docs template normalize.
- Axis helper, camera fit, measure-mode polish; shared AnalysisChart for analysis panels.
- Bump product versions to **0.1.1** (core / page / vsc-ext / python).

## Test plan
- [x] Local pre-commit: biome, typecheck, core tests (724)
- [x] Local pre-push: build core + check:pack + build page + build vsc-ext
- [ ] CI on this PR (lint / typecheck / test-core / build-*)